### PR TITLE
Improve coverage

### DIFF
--- a/test/embulk/input/mixpanel_api/test_client.rb
+++ b/test/embulk/input/mixpanel_api/test_client.rb
@@ -31,10 +31,17 @@ module Embulk
             super
 
             @httpclient = HTTPClient.new
-            stub(@client).httpclient { @httpclient }
+          end
+
+          def test_httpclient
+            stub_response(success_response)
+            mock(@client).httpclient { @httpclient }
+
+            @client.export(params)
           end
 
           def test_response_class
+            stub_client
             stub_response(success_response)
 
             actual = @client.export(params)
@@ -43,6 +50,7 @@ module Embulk
           end
 
           def test_http_request
+            stub_client
             mock(@httpclient).get(Client::ENDPOINT_EXPORT, params) do
               success_response
             end
@@ -51,6 +59,7 @@ module Embulk
           end
 
           def test_success
+            stub_client
             stub_response(success_response)
 
             actual = @client.export(params)
@@ -59,6 +68,7 @@ module Embulk
           end
 
           def test_failure
+            stub_client
             stub_response(failure_response)
 
             stub(Embulk.logger).error(failure_response.body) {}
@@ -68,6 +78,7 @@ module Embulk
           end
 
           def test_failure_logging
+            stub_client
             stub_response(failure_response)
 
             mock(Embulk.logger).error(failure_response.body) {}
@@ -75,6 +86,10 @@ module Embulk
           end
 
           private
+
+          def stub_client
+            stub(@client).httpclient { @httpclient }
+          end
 
           def stub_response(response)
             stub(@httpclient).get(Client::ENDPOINT_EXPORT, params) do

--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -162,6 +162,7 @@ module Embulk
           schema: [
             {"name" => "foo", "type" => "long"},
             {"name" => "time", "type" => "long"},
+            {"name" => "event", "type" => "string"},
           ],
           dates: (Date.parse(FROM_DATE)..Date.parse(TO_DATE)).to_a,
           params: Mixpanel.export_params(embulk_config),

--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -9,6 +9,7 @@ module Embulk
       API_SECRET = "api_secret".freeze
       FROM_DATE = "2015-02-22".freeze
       TO_DATE = "2015-03-02".freeze
+      TIMEZONE = "Asia/Tokyo".freeze
 
       DURATIONS = [
         {from_date: FROM_DATE, to_date: "2015-02-28"}, # It has 7 days between 2015-02-22 and 2015-02-28
@@ -58,14 +59,14 @@ module Embulk
 
       class TransactionTest < self
         def test_valid_timezone
-          timezone = "Asia/Tokyo"
+          timezone = TIMEZONE
           mock(Mixpanel).resume(transaction_task(timezone), columns, 1, &control)
 
           Mixpanel.transaction(transaction_config(timezone), &control)
         end
 
         def test_invalid_timezone
-          timezone = "Asia/Tokyoooooo"
+          timezone = "#{TIMEZONE}ooooo"
 
           assert_raise(TZInfo::InvalidTimezoneIdentifier) do
             Mixpanel.transaction(transaction_config(timezone), &control)
@@ -73,7 +74,7 @@ module Embulk
         end
 
         def test_resume
-          actual = Mixpanel.resume(transaction_task("Asia/Tokyo"), columns, 1, &control)
+          actual = Mixpanel.resume(transaction_task(TIMEZONE), columns, 1, &control)
           assert_equal({}, actual)
         end
 
@@ -185,7 +186,7 @@ module Embulk
         {
           api_key: API_KEY,
           api_secret: API_SECRET,
-          timezone: "Asia/Tokyo",
+          timezone: TIMEZONE,
           schema: schema,
           dates: (Date.parse(FROM_DATE)..Date.parse(TO_DATE)).to_a,
           params: Mixpanel.export_params(embulk_config),

--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -140,6 +140,14 @@ module Embulk
           @plugin = Mixpanel.new(task, nil, nil, @page_builder)
         end
 
+        def test_preview_check
+          mock(@plugin).preview? { true }
+          stub(@page_builder).add(anything)
+          stub(@page_builder).finish
+
+          @plugin.run
+        end
+
         def test_preview
           stub(@plugin).preview? { true }
           mock(@page_builder).add(anything).times(records.length)

--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -72,6 +72,11 @@ module Embulk
           end
         end
 
+        def test_resume
+          actual = Mixpanel.resume(transaction_task("Asia/Tokyo"), columns, 1, &control)
+          assert_equal({}, actual)
+        end
+
         def control
           proc {} # dummy
         end


### PR DESCRIPTION
Some tests is needed but are not implemented yet.
c.f. https://codeclimate.com/github/treasure-data/embulk-input-mixpanel/coverage
- [x] Mixpanel.transaction
- [x] event column in Mixpanel.run
- [x] Mixpanel.resume (called from .transaction)
- [x] Mixpanel.preview? (called from #run)
- [x] MixpanelApi::client.htttpclient (called from #export)
