### PR TITLE
Fix guess with recently from date

### DIFF
--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -100,9 +100,9 @@ module Embulk
           raise ConfigError, "Please specify date later than yesterday (inclusive) as 'from_date'"
         end
 
-        # NOTE: It should have 7 days between from_date and to_date
-        to_date = from_date + SLICE_DAYS_COUNT
-        to_date = Date.today - 1 if to_date > (Date.today - 1)
+        # NOTE: to_date is yeasterday if from_date..Date.Today doesn't have
+        # more SLICE_DAYS_COUNT days.
+        to_date = [from_date + SLICE_DAYS_COUNT, Date.today - 1].min
 
         params = export_params(config)
         params = params.merge(

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -92,7 +92,7 @@ module Embulk
       def self.guess(config)
         client = MixpanelApi::Client.new(config.param(:api_key, :string), config.param(:api_secret, :string))
 
-        from_date_str = config.param(:from_date, :string, default: (Date.today - 2 - SLICE_DAYS_COUNT).to_s)
+        from_date_str = config.param(:from_date, :string, default: (Date.today - 1 - SLICE_DAYS_COUNT).to_s)
 
         from_date = Date.parse(from_date_str)
 
@@ -101,7 +101,7 @@ module Embulk
         end
 
         # NOTE: It should have 7 days between from_date and to_date
-        to_date = from_date + SLICE_DAYS_COUNT - 1
+        to_date = from_date + SLICE_DAYS_COUNT
         to_date = Date.today - 1 if to_date > (Date.today - 1)
 
         params = export_params(config)

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -92,14 +92,22 @@ module Embulk
       def self.guess(config)
         client = MixpanelApi::Client.new(config.param(:api_key, :string), config.param(:api_secret, :string))
 
-        from_date = config.param(:from_date, :string, default: (Date.today - 2 - SLICE_DAYS_COUNT).to_s)
+        from_date_str = config.param(:from_date, :string, default: (Date.today - 2 - SLICE_DAYS_COUNT).to_s)
+
+        from_date = Date.parse(from_date_str)
+
+        if from_date > (Date.today - 1)
+          raise ConfigError, "Please specify date later than yesterday (inclusive) as `from_date`"
+        end
+
         # NOTE: It should have 7 days between from_date and to_date
-        to_date = (Date.parse(from_date) + SLICE_DAYS_COUNT - 1).to_s
+        to_date = from_date + SLICE_DAYS_COUNT - 1
+        to_date = Date.today - 1 if to_date > (Date.today - 1)
 
         params = export_params(config)
         params = params.merge(
-          from_date: from_date,
-          to_date: to_date,
+          from_date: from_date_str,
+          to_date: to_date.to_s,
         )
 
         records = client.export(params)

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -96,7 +96,7 @@ module Embulk
 
         from_date = Date.parse(from_date_str)
 
-        if from_date > (Date.today - 1)
+        if from_date > Date.today - 1
           raise ConfigError, "Please specify date later than yesterday (inclusive) as `from_date`"
         end
 

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -97,7 +97,7 @@ module Embulk
         from_date = Date.parse(from_date_str)
 
         if from_date > Date.today - 1
-          raise ConfigError, "Please specify date later than yesterday (inclusive) as `from_date`"
+          raise ConfigError, "Please specify date later than yesterday (inclusive) as 'from_date'"
         end
 
         # NOTE: It should have 7 days between from_date and to_date

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -106,7 +106,7 @@ module Embulk
 
         params = export_params(config)
         params = params.merge(
-          from_date: from_date_str,
+          from_date: from_date.to_s,
           to_date: to_date.to_s,
         )
 

--- a/lib/embulk/input/mixpanel_api/client.rb
+++ b/lib/embulk/input/mixpanel_api/client.rb
@@ -19,6 +19,9 @@ module Embulk
           # https://mixpanel.com/docs/api-documentation/exporting-raw-data-you-inserted-into-mixpanel
           params[:expire] ||= Time.now.to_i + TIMEOUT_SECONDS
           params[:sig] = signature(params)
+
+          Embulk.logger.debug "Export param: #{params.to_s}"
+
           response = httpclient.get(ENDPOINT_EXPORT, params)
 
           if (400..499).include?(response.code)

--- a/lib/embulk/input/mixpanel_api/client.rb
+++ b/lib/embulk/input/mixpanel_api/client.rb
@@ -24,6 +24,8 @@ module Embulk
 
           response = httpclient.get(ENDPOINT_EXPORT, params)
 
+          Embulk.logger.debug "response code: #{response.code}"
+
           if (400..499).include?(response.code)
             raise ConfigError, response.body
           elsif response.code >= 500

--- a/test/embulk/input/mixpanel_api/test_client.rb
+++ b/test/embulk/input/mixpanel_api/test_client.rb
@@ -9,6 +9,7 @@ module Embulk
 
         def setup
           @client = Client.new(API_KEY, API_SECRET)
+          stub(Embulk).logger { ::Logger.new(IO::NULL) }
         end
 
         # NOTE: Client#signature is private method but this value

--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -92,6 +92,21 @@ module Embulk
           assert_equal(expected, actual)
         end
 
+        def test_no_from_date
+          config = {
+            type: "mixpanel",
+            api_key: API_KEY,
+            api_secret: API_SECRET,
+          }
+
+          from_date = Date.today - 1 - Mixpanel::SLICE_DAYS_COUNT
+          to_date = Date.today - 1
+          stub_export(from_date, to_date)
+
+          actual = Mixpanel.guess(embulk_config(config))
+          assert_equal(expected, actual)
+        end
+
         private
 
         def stub_export(from_date, to_date)


### PR DESCRIPTION
- Raise ConfigError when `from_date` is earlier than yesterday (exclusive)
- Truncate `to_date` being later than yesterday
- Show parameter for export API and its response code as debug log
- Fix broken tests
