### PR TITLE
Fix the bug 1 day data cant be fetched

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To get it, you should log in mixpanel website, and click gear icon at the lower 
 - **timezone**: project timezone(string, required)
 - **from_date**: From date to export (string, optional, default: today - 2)
   - NOTE: Mixpanel API supports to export data from at least 2 days before to at most the previous day.
-- **days**: Count of days range for exporting (integer, optional, default: from_date - (today - 1))
+- **fetch_days**: Count of days range for exporting (integer, optional, default: from_date - (today - 1))
   - NOTE: Mixpanel doesn't support to from_date > today - 2
 - **event**: The event or events to filter data (array, optional, default: nil)
 - **where**: Expression to filter data (c.f. https://mixpanel.com/docs/api-documentation/data-export-api#segmentation-expressions) (string, optional, default: nil)
@@ -51,7 +51,7 @@ in:
   api_secret: "API_SECRET"
   timezone: "US/Pacific"
   from_date: "2015-07-19"
-  days: 5
+  fetch_days: 5
 ```
 
 ## Run test

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -40,7 +40,7 @@ module Embulk
           else
             # When 'days' is specified in config file and it is satisfied,
             # so it is used for dates.
-            dates = from_date..(from_date + days)
+            dates = from_date..(from_date + days - 1)
           end
 
           target_dates = dates.find_all {|date| date < Date.today}

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -29,7 +29,7 @@ module Embulk
           Embulk.logger.warn "Mixpanel allow 2 days before to from_date, so no data is input."
           target_dates = []
         else
-          days = config.param(:days, :integer, default: nil)
+          days = config.param(:fetch_days, :integer, default: nil)
 
           if days.nil?
             # When no 'days' is specified in config file, so dates is

--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -10,7 +10,7 @@ module Embulk
       FROM_DATE = "2015-02-22".freeze
       TO_DATE = "2015-03-02".freeze
       DAYS = 8
-      DATES = Date.parse(FROM_DATE)..(Date.parse(FROM_DATE) + DAYS)
+      DATES = Date.parse(FROM_DATE)..(Date.parse(FROM_DATE) + DAYS - 1)
       TIMEZONE = "Asia/Tokyo".freeze
 
       DURATIONS = [
@@ -279,7 +279,7 @@ module Embulk
           def transaction_task(days)
             from_date = Date.parse(FROM_DATE)
             task.merge(
-              dates: (from_date..(from_date + days)).map {|date| date.to_s},
+              dates: (from_date..(from_date + days - 1)).map {|date| date.to_s},
               api_key: API_KEY,
               api_secret: API_SECRET,
               timezone: TIMEZONE,

--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -165,7 +165,7 @@ module Embulk
 
         def test_negative_days
           assert_raise(Embulk::ConfigError) do
-            Mixpanel.transaction(transaction_config((Date.today - 1).to_s).merge(days: -1))
+            Mixpanel.transaction(transaction_config((Date.today - 1).to_s).merge(fetch_days: -1))
           end
         end
 
@@ -213,7 +213,7 @@ module Embulk
           def transaction_config
             _config = config.merge(
               from_date: dates.first.to_s,
-              days: dates.to_a.size,
+              fetch_days: dates.to_a.size,
               timezone: TIMEZONE,
               columns: schema
             )
@@ -289,7 +289,7 @@ module Embulk
 
           def transaction_config(days)
             _config = config.merge(
-              days: days,
+              fetch_days: days,
               columns: schema,
               timezone: TIMEZONE,
             )
@@ -449,7 +449,7 @@ module Embulk
           api_key: API_KEY,
           api_secret: API_SECRET,
           from_date: FROM_DATE,
-          days: DAYS,
+          fetch_days: DAYS,
         }
       end
 


### PR DESCRIPTION
Before, `days` configuration doesn't means a count of days correctly. e.g. `from_date` is `2015-08-28` and `days` is `3` in config means this plugin uses 2015-08-28, 29, 30, 31 (4 days), but we expepcts 2015-08-28, 29, 30 (3 days). This PR fixes it.

Furthermore, `days` configuration isn't readable so I changed to `fetch_days` also.
