### PR TITLE
Create unknown_columns only when option is true

### DIFF
--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -333,12 +333,9 @@ module Embulk
         end
 
         def columns
-          unknown_columns = [Column.new(nil, "unknown_columns", :string)]
-          configured_columns = schema.map do |col|
+          schema.map do |col|
             Column.new(nil, col["name"], col["type"].to_sym)
           end
-
-          configured_columns + unknown_columns
         end
       end
 


### PR DESCRIPTION
`unknown_column` is needed only when `fetch_unknown_columns` option is true.
