### PR TITLE
Reduce data bytes with range

### DIFF
--- a/test/embulk/input/mixpanel_api/test_client.rb
+++ b/test/embulk/input/mixpanel_api/test_client.rb
@@ -92,7 +92,7 @@ module Embulk
           class ExportSmallDataset < self
             def test_to_date_after_1_day
               to = (Date.parse(params["from_date"]) + 1).to_s
-              mock(@client).request(params.merge("to_date" => to)) { jsonl_dummy_responses }
+              mock(@client).request(params.merge("to_date" => to), Client::SMALLSET_BYTE_RANGE) { jsonl_dummy_responses }
 
               @client.export_for_small_dataset(params)
             end
@@ -100,14 +100,14 @@ module Embulk
             def test_to_date_after_1_day_after_10_days_if_empty
               to1 = (Date.parse(params["from_date"]) + 1).to_s
               to2 = (Date.parse(params["from_date"]) + 10).to_s
-              mock(@client).request(params.merge("to_date" => to1)) { "" }
-              mock(@client).request(params.merge("to_date" => to2)) { jsonl_dummy_responses }
+              mock(@client).request(params.merge("to_date" => to1), Client::SMALLSET_BYTE_RANGE) { "" }
+              mock(@client).request(params.merge("to_date" => to2), Client::SMALLSET_BYTE_RANGE) { jsonl_dummy_responses }
 
               @client.export_for_small_dataset(params)
             end
 
             def test_config_error_when_too_long_empty_dates
-              stub(@client).request(anything) { "" }
+              stub(@client).request(anything, anything) { "" }
 
               assert_raise(Embulk::ConfigError) do
                 @client.export_for_small_dataset(params)


### PR DESCRIPTION
If Mixpanel has huge data in 1 day, current implementation will fetch it all.
This PR solves it with HTTP Range header to reduce transfer byte size at most 5MB.
