### PR TITLE
Custom properties json

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@ To get it, you should log in mixpanel website, and click gear icon at the lower 
   - NOTE: Mixpanel doesn't support to from_date > today - 2
 - **fetch_unknown_columns**(deprecated): If you want this plugin fetches unknown (unconfigured in config) columns (boolean, optional, default: true)
   - NOTE: If true, `unknown_columns` column is created and added unknown columns' data.
-- **custom_properties_json**: All custom properties into `custom_properties` key. "custom properties" are not desribed Mixpanel document [1](https://mixpanel.com/help/questions/articles/special-or-reserved-properties), [2](https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default).  (boolean, optional, default: false)
-  - NOTE: Cannot set both `fetch_unknown_columns` and `custom_properties_json` to `true`.
+- **fetch_custom_properties**: All custom properties into `custom_properties` key. "custom properties" are not desribed Mixpanel document [1](https://mixpanel.com/help/questions/articles/special-or-reserved-properties), [2](https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default).  (boolean, optional, default: false)
+  - NOTE: Cannot set both `fetch_unknown_columns` and `fetch_custom_properties` to `true`.
 - **event**: The event or events to filter data (array, optional, default: nil)
 - **where**: Expression to filter data (c.f. https://mixpanel.com/docs/api-documentation/data-export-api#segmentation-expressions) (string, optional, default: nil)
 - **bucket**:The data backet to filter data (string, optional, default: nil)
 - **retry_initial_wait_sec** Wait seconds for exponential backoff initial value (integer, default: 1)
 - **retry_limit**: Try to retry this times (integer, default: 5)
 
-### `fetch_unknown_columns` and `custom_properties_json`
+### `fetch_unknown_columns` and `fetch_custom_properties`
 
 If you have such data and set config.yml as below.
 
@@ -78,7 +78,7 @@ in:
 | ----- | ------- | ----------------- |
 | ev    | custom  | `{"$city":"Tokyo", "$foobar": "foobar"}` |
 
-`custom_properties_json: true` will fetch as:
+`fetch_custom_properties: true` will fetch as:
 
 | event | $custom | custom_properties (json) |
 | ----- | ------- | ----------------- |
@@ -87,7 +87,7 @@ in:
 
 `fetch_unknown_columns` recognize `$city` and `$foobar` as `unknown_columns` because they are not described in config.yml.
 
-`custom_properties_json` recognize `$foobar` as `custom_properties`. `$custom` is also custom property but it was described in config.yml.
+`fetch_custom_properties` recognize `$foobar` as `custom_properties`. `$custom` is also custom property but it was described in config.yml.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,56 @@ To get it, you should log in mixpanel website, and click gear icon at the lower 
   - NOTE: Mixpanel API supports to export data from at least 2 days before to at most the previous day.
 - **fetch_days**: Count of days range for exporting (integer, optional, default: from_date - (today - 1))
   - NOTE: Mixpanel doesn't support to from_date > today - 2
-- **fetch_unknown_columns**: If you want this plugin fetches unknown (unconfigured in config) columns (boolean, optional, default: true)
+- **fetch_unknown_columns**(deprecated): If you want this plugin fetches unknown (unconfigured in config) columns (boolean, optional, default: true)
   - NOTE: If true, `unknown_columns` column is created and added unknown columns' data.
+- **custom_properties_json**: All custom properties into `custom_properties` key. "custom properties" are not desribed Mixpanel document [1](https://mixpanel.com/help/questions/articles/special-or-reserved-properties), [2](https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default).  (boolean, optional, default: false)
+  - NOTE: Cannot set both `fetch_unknown_columns` and `custom_properties_json` to `true`.
 - **event**: The event or events to filter data (array, optional, default: nil)
 - **where**: Expression to filter data (c.f. https://mixpanel.com/docs/api-documentation/data-export-api#segmentation-expressions) (string, optional, default: nil)
 - **bucket**:The data backet to filter data (string, optional, default: nil)
 - **retry_initial_wait_sec** Wait seconds for exponential backoff initial value (integer, default: 1)
 - **retry_limit**: Try to retry this times (integer, default: 5)
+
+### `fetch_unknown_columns` and `custom_properties_json`
+
+If you have such data and set config.yml as below.
+
+| event | $city   | $custom | $foobar |
+| ----- | ------- | ------- | ------- |
+| ev    | Tokyo   | custom  | foobar  |
+
+(NOTE: `$city` is a [reserved key](https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default), `$custom` and `$foobar` are not)
+
+```yaml
+in:
+  type: mixpanel
+  api_key: "API_KEY"
+  api_secret: "API_SECRET"
+  timezone: "US/Pacific"
+  from_date: "2015-07-19"
+  fetch_days: 5
+  columns:
+    - {name: event, type: string}
+    - {name: $custom, type: string}
+```
+
+
+`fetch_unknown_columns: true` will fetch as:
+
+| event | $custom | unknown_columns (json) |
+| ----- | ------- | ----------------- |
+| ev    | custom  | `{"$city":"Tokyo", "$foobar": "foobar"}` |
+
+`custom_properties_json: true` will fetch as:
+
+| event | $custom | custom_properties (json) |
+| ----- | ------- | ----------------- |
+| ev    | custom  | `{"$foobar": "foobar"}` |
+
+
+`fetch_unknown_columns` recognize `$city` and `$foobar` as `unknown_columns` because they are not described in config.yml.
+
+`custom_properties_json` recognize `$foobar` as `custom_properties`. `$custom` is also custom property but it was described in config.yml.
 
 ## Example
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ task default: :test
 
 desc "Run tests"
 task :test do
-  ruby("test/run-test.rb", "--use-color=yes", "--collector=dir")
+  ruby("--debug", "test/run-test.rb", "--use-color=yes", "--collector=dir")
 end
 
 Everyleaf::EmbulkHelper::Tasks.install(

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -48,13 +48,13 @@ module Embulk
           api_secret: config.param(:api_secret, :string),
           schema: config.param(:columns, :array),
           fetch_unknown_columns: fetch_unknown_columns,
-          custom_properties_json: config.param(:custom_properties_json, :bool, default: false),
+          fetch_custom_properties: config.param(:fetch_custom_properties, :bool, default: false),
           retry_initial_wait_sec: config.param(:retry_initial_wait_sec, :integer, default: 1),
           retry_limit: config.param(:retry_limit, :integer, default: 5),
         }
 
-        if task[:fetch_unknown_columns] && task[:custom_properties_json]
-          raise Embulk::ConfigError.new("Don't set true both `fetch_unknown_columns` and `custom_properties_json`.")
+        if task[:fetch_unknown_columns] && task[:fetch_custom_properties]
+          raise Embulk::ConfigError.new("Don't set true both `fetch_unknown_columns` and `fetch_custom_properties`.")
         end
 
         columns = task[:schema].map do |column|
@@ -65,11 +65,11 @@ module Embulk
         end
 
         if fetch_unknown_columns
-          Embulk.logger.warn "Deprecated `unknown_columns`. Use `custom_properties_json` instead."
+          Embulk.logger.warn "Deprecated `unknown_columns`. Use `fetch_custom_properties` instead."
           columns << Column.new(nil, "unknown_columns", :json)
         end
 
-        if task[:custom_properties_json]
+        if task[:fetch_custom_properties]
           columns << Column.new(nil, "custom_properties", :json)
         end
 
@@ -137,7 +137,7 @@ module Embulk
               unknown_values = extract_unknown_values(record)
               values << unknown_values.to_json
             end
-            if task[:custom_properties_json]
+            if task[:fetch_custom_properties]
               values << collect_custom_properties(record)
             end
             page_builder.add(values)

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -36,9 +36,14 @@ module Embulk
           api_secret: config.param(:api_secret, :string),
           schema: config.param(:columns, :array),
           fetch_unknown_columns: fetch_unknown_columns,
+          custom_properties_json: config.param(:custom_properties_json, :bool, default: false),
           retry_initial_wait_sec: config.param(:retry_initial_wait_sec, :integer, default: 1),
           retry_limit: config.param(:retry_limit, :integer, default: 5),
         }
+
+        if task[:fetch_unknown_columns] && task[:custom_properties_json]
+          raise Embulk::ConfigError.new("Don't set true both `fetch_unknown_columns` and `custom_properties_json`.")
+        end
 
         columns = task[:schema].map do |column|
           name = column["name"]
@@ -48,6 +53,7 @@ module Embulk
         end
 
         if fetch_unknown_columns
+          Embulk.logger.warn "Deprecated `unknown_columns`. Use `custom_properties_json` instead."
           columns << Column.new(nil, "unknown_columns", :json)
         end
 

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -12,6 +12,18 @@ module Embulk
       GUESS_RECORDS_COUNT = 10
       NOT_PROPERTY_COLUMN = "event".freeze
 
+      # https://mixpanel.com/help/questions/articles/special-or-reserved-properties
+      # https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default
+      #
+      # JavaScript to extract key names from HTML: run it on Chrome Devtool when opening their document
+      # > Array.from(document.querySelectorAll("strong")).map(function(s){ return s.textContent.match(/[A-Z]/) ? s.parentNode.textContent.match(/\((.*?)\)/)[1] : s.textContent.split(",").join(" ") }).join(" ")
+      # > Array.from(document.querySelectorAll("li")).map(function(s){ m = s.textContent.match(/\((.*?)\)/); return m && m[1] }).filter(function(k) { return k && !k.match("utm") }).join(" ")
+      KNOWN_KEYS = %W(
+        #{NOT_PROPERTY_COLUMN}
+        distinct_id ip mp_name_tag mp_note token time mp_country_code length campaign_id $email $phone $distinct_id $ios_devices $android_devices $first_name  $last_name  $name $city $region $country_code $timezone $unsubscribed
+        $city $region mp_country_code $browser $browser_version $device $current_url $initial_referrer $initial_referring_domain $os $referrer $referring_domain $screen_height $screen_width $search_engine $city $region $mp_country_code $timezone $browser_version $browser $initial_referrer $initial_referring_domain $os $last_seen $city $region mp_country_code $app_release $app_version $carrier $ios_ifa $os_version $manufacturer $lib_version $model $os $screen_height $screen_width $wifi $city $region $mp_country_code $timezone $ios_app_release $ios_app_version $ios_device_model $ios_lib_version $ios_version $ios_ifa $last_seen $city $region mp_country_code $app_version $bluetooth_enabled $bluetooth_version $brand $carrier $has_nfc $has_telephone $lib_version $manufacturer $model $os $os_version $screen_dpi $screen_height $screen_width $wifi $google_play_services $city $region mp_country_code $timezone $android_app_version $android_app_version_code $android_lib_version $android_os $android_os_version $android_brand $android_model $android_manufacturer $last_seen
+      ).uniq.freeze
+
       # NOTE: It takes long time to fetch data between from_date to
       # to_date by one API request. So this plugin fetches data
       # between each 7 (SLICE_DAYS_COUNT) days.
@@ -55,6 +67,10 @@ module Embulk
         if fetch_unknown_columns
           Embulk.logger.warn "Deprecated `unknown_columns`. Use `custom_properties_json` instead."
           columns << Column.new(nil, "unknown_columns", :json)
+        end
+
+        if task[:custom_properties_json]
+          columns << Column.new(nil, "custom_properties", :json)
         end
 
         resume(task, columns, 1, &control)
@@ -121,6 +137,9 @@ module Embulk
               unknown_values = extract_unknown_values(record)
               values << unknown_values.to_json
             end
+            if task[:custom_properties_json]
+              values << collect_custom_properties(record)
+            end
             page_builder.add(values)
           end
 
@@ -156,6 +175,16 @@ module Embulk
           adjust_timezone(time)
         else
           record["properties"][name]
+        end
+      end
+
+      def collect_custom_properties(record)
+        specified_columns = @schema.map{|col| col["name"]}
+        custom_keys = record["properties"].keys.find_all{|key| !KNOWN_KEYS.include?(key.to_s) && !specified_columns.include?(key.to_s) }
+        custom_keys.inject({}) do |result, key|
+          result.merge({
+            key => record["properties"][key]
+          })
         end
       end
 

--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -346,8 +346,8 @@ module Embulk
             "true/false" => [true, false],
           )
           def test_valid_combination(data)
-            fetch_unknown_columns, custom_properties_json = data
-            conf = DataSource[*transaction_config.merge(fetch_unknown_columns: fetch_unknown_columns, custom_properties_json: custom_properties_json).to_a.flatten(1)]
+            fetch_unknown_columns, fetch_custom_properties = data
+            conf = DataSource[*transaction_config.merge(fetch_unknown_columns: fetch_unknown_columns, fetch_custom_properties: fetch_custom_properties).to_a.flatten(1)]
 
             assert_nothing_raised do
               Mixpanel.transaction(conf, &control)
@@ -355,7 +355,7 @@ module Embulk
           end
 
           def test_both_true_then_raise_config_error
-            conf = DataSource[*transaction_config.merge(fetch_unknown_columns: true, custom_properties_json: true).to_a.flatten(1)]
+            conf = DataSource[*transaction_config.merge(fetch_unknown_columns: true, fetch_custom_properties: true).to_a.flatten(1)]
 
             assert_raise(Embulk::ConfigError) do
               Mixpanel.transaction(conf, &control)
@@ -501,7 +501,7 @@ module Embulk
             dates: DATES.to_a.map(&:to_s),
             params: Mixpanel.export_params(embulk_config),
             fetch_unknown_columns: false,
-            custom_properties_json: false,
+            fetch_custom_properties: false,
             retry_initial_wait_sec: 0,
             retry_limit: 3,
           }
@@ -576,7 +576,7 @@ module Embulk
           private
 
           def task
-            super.merge(schema: schema, fetch_unknown_columns: false, custom_properties_json: true)
+            super.merge(schema: schema, fetch_unknown_columns: false, fetch_custom_properties: true)
           end
 
           def record
@@ -670,7 +670,7 @@ module Embulk
           dates: DATES.to_a.map(&:to_s),
           params: Mixpanel.export_params(embulk_config),
           fetch_unknown_columns: false,
-          custom_properties_json: false,
+          fetch_custom_properties: false,
           retry_initial_wait_sec: 2,
           retry_limit: 3,
         }
@@ -705,7 +705,7 @@ module Embulk
           from_date: FROM_DATE,
           fetch_days: DAYS,
           fetch_unknown_columns: false,
-          custom_properties_json: false,
+          fetch_custom_properties: false,
           retry_initial_wait_sec: 2,
           retry_limit: 3,
         }

--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -13,14 +13,12 @@ $LOAD_PATH.unshift(test_dir)
 
 ENV["TEST_UNIT_MAX_DIFF_TARGET_STRING_SIZE"] ||= "5000"
 
-if ENV["COVERAGE"]
-  if ENV["CI"]
-    require "codeclimate-test-reporter"
-    CodeClimate::TestReporter.start
-  else
-    require 'simplecov'
-    SimpleCov.start 'test_frameworks'
-  end
+if ENV["CI"]
+  require "codeclimate-test-reporter"
+  CodeClimate::TestReporter.start
+elsif ENV["COVERAGE"]
+  require 'simplecov'
+  SimpleCov.start 'test_frameworks'
 end
 
 exit Test::Unit::AutoRunner.run(true, test_dir)

--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -13,6 +13,14 @@ $LOAD_PATH.unshift(test_dir)
 
 ENV["TEST_UNIT_MAX_DIFF_TARGET_STRING_SIZE"] ||= "5000"
 
-CodeClimate::TestReporter.start
+if ENV["COVERAGE"]
+  if ENV["CI"]
+    require "codeclimate-test-reporter"
+    CodeClimate::TestReporter.start
+  else
+    require 'simplecov'
+    SimpleCov.start 'test_frameworks'
+  end
+end
 
 exit Test::Unit::AutoRunner.run(true, test_dir)


### PR DESCRIPTION
Deprecate `fetch_unknown_columns` option described in README changes.
But current default setting is `fetch_unknown_columns: true` and `custom_properties_json: false` for compatibility.
# Schedule & Compatibility

Next release contain this PR changes. Just warning if `fetch_unknown_columns` is set true.
Some months later, `fetch_unknown_columns: false` and `custom_properties_json: true` to be new default values. But `fetch_unknown_columns: true` can be used.
Next months, `fetch_unknown_columns` option will be removed.
