### PR TITLE
Reduce memory usage by streaming processing

### DIFF
--- a/embulk-input-mixpanel.gemspec
+++ b/embulk-input-mixpanel.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'httpclient'
   spec.add_dependency 'tzinfo'
-  spec.add_dependency 'perfect_retry', ["~> 0.3"]
+  spec.add_dependency 'perfect_retry', ["~> 0.5"]
   spec.add_development_dependency 'bundler', ['~> 1.0']
   spec.add_development_dependency 'rake', ['>= 10.0']
   spec.add_development_dependency 'embulk', ['>= 0.8.6', '< 1.0']

--- a/lib/embulk/input/mixpanel_api/client.rb
+++ b/lib/embulk/input/mixpanel_api/client.rb
@@ -14,6 +14,8 @@ module Embulk
         PING_RETRY_WAIT = 2
         SMALLSET_BYTE_RANGE = "0-#{5 * 1024 * 1024}"
 
+        attr_reader :retryer
+
         def self.mixpanel_available?
           retryer = PerfectRetry.new do |config|
             config.limit = PING_RETRY_LIMIT
@@ -34,31 +36,42 @@ module Embulk
           end
         end
 
-        def initialize(api_key, api_secret)
+        def initialize(api_key, api_secret, retryer = nil)
           @api_key = api_key
           @api_secret = api_secret
-        end
-
-        def export(params = {})
-          body = request(params)
-          response_to_enum(body)
-        end
-
-        def export_for_small_dataset(params = {}, times = 0)
-          days = (1 * (10 ** times))
-          to_date = Date.parse(params["from_date"].to_s) + days
-          params["to_date"] = to_date.strftime("%Y-%m-%d")
-
-          body = request(params, SMALLSET_BYTE_RANGE)
-          result = response_to_enum(body)
-          if result.first.nil?
-            if times >= 5
-              raise ConfigError.new "#{params["from_date"]} + #{days} days has no record. too old date?"
-            end
-            export_for_small_dataset(params, times + 1)
-          else
-            result
+          @retryer = retryer || PerfectRetry.new do |config|
+            # for test
+            config.limit = 0
+            config.dont_rescues = [RuntimeError]
+            config.log_level = nil
+            config.logger = Embulk.logger
+            config.raise_original_error = true
           end
+        end
+
+        def export(params = {}, &block)
+          retryer.with_retry do
+            request(params, &block)
+          end
+        end
+
+        def export_for_small_dataset(params = {})
+          try_to_dates = 5.times.map do |n|
+            # from_date + 1, from_date + 10, from_date + 100, ... so on
+            days = 1 * (10 ** n)
+            Date.parse(params["from_date"].to_s) + days
+          end
+
+          try_to_dates.each do |to_date|
+            params["to_date"] = to_date.strftime("%Y-%m-%d")
+            records = retryer.with_retry do
+              request_small_dataset(params, SMALLSET_BYTE_RANGE)
+            end
+            next if records.first.nil?
+            return records
+          end
+
+          raise ConfigError.new "#{params["from_date"]} + #{days} days has no record. too old date?"
         end
 
         private
@@ -72,34 +85,53 @@ module Embulk
           end
         end
 
-        def request(params, range = nil)
+        def request(params, &block)
           # https://mixpanel.com/docs/api-documentation/exporting-raw-data-you-inserted-into-mixpanel
-          params[:expire] ||= Time.now.to_i + TIMEOUT_SECONDS
-          params[:sig] = signature(params)
           Embulk.logger.debug "Export param: #{params.to_s}"
+          set_signatures(params)
 
-          headers = {}
-          response =
-            if range
-              # guess/preview
-              res = httpclient.get(ENDPOINT_EXPORT, params, {"Range" => "bytes=#{range}"})
-              if res.code == 416
-                # cannot satisfied requested Range, get full body
-                httpclient.get(ENDPOINT_EXPORT, params)
-              else
-                res
+          buf = ""
+          response = httpclient.get(ENDPOINT_EXPORT, params) do |chunk|
+            chunk.each_line do |line|
+              begin
+                record = JSON.parse(buf + line)
+                block.call record
+                buf = ""
+              rescue JSON::ParserError => e
+                buf << line
               end
-            else
-              httpclient.get(ENDPOINT_EXPORT, params)
             end
+          end
+          handle_error(response)
+        end
+
+        def request_small_dataset(params, range)
+          # guess/preview
+          # Try to fetch first `range` bytes
+          set_signatures(params)
+          res = httpclient.get(ENDPOINT_EXPORT, params, {"Range" => "bytes=#{range}"})
+          if res.code == 416
+            # cannot satisfied requested Range, get full body
+            res = httpclient.get(ENDPOINT_EXPORT, params)
+          end
+          handle_error(res)
+          response_to_enum(res.body)
+        end
+
+        def handle_error(response)
           Embulk.logger.debug "response code: #{response.code}"
           case response.code
           when 400..499
-            raise ConfigError.new response.body
+            raise ConfigError.new("[#{response.code}] #{response.body}")
           when 500..599
-            raise RuntimeError, response.body
+            raise RuntimeError.new("[#{response.code}] #{response.body}")
           end
-          response.body
+        end
+
+        def set_signatures(params)
+          params[:expire] ||= Time.now.to_i + TIMEOUT_SECONDS
+          params[:sig] = signature(params)
+          params
         end
 
         def signature(params)
@@ -121,6 +153,7 @@ module Embulk
               client = HTTPClient.new
               client.receive_timeout = TIMEOUT_SECONDS
               client.default_header = {Accept: "application/json; charset=UTF-8"}
+              # client.debug_dev = STDERR
               client
             end
         end

--- a/lib/embulk/input/mixpanel_api/client.rb
+++ b/lib/embulk/input/mixpanel_api/client.rb
@@ -71,7 +71,7 @@ module Embulk
             return records
           end
 
-          raise ConfigError.new "#{params["from_date"]} + #{days} days has no record. too old date?"
+          raise ConfigError.new "#{params["from_date"]}..#{try_to_dates.last} has no record. too old date?"
         end
 
         private


### PR DESCRIPTION
When got huge (over 1GB) response, it would be caused OutOfMemory error in the processing.
Luckily Mixpanel response is jsonl instead of huge JSON so we can do it as steaming processing.
It reduces memory usage even if response size is huge.
