### PR TITLE
Retry with too frequency requests error

### DIFF
--- a/lib/embulk/input/mixpanel_api/client.rb
+++ b/lib/embulk/input/mixpanel_api/client.rb
@@ -131,6 +131,10 @@ module Embulk
           Embulk.logger.debug "response code: #{response.code}"
           case response.code
           when 400..499
+            if response.code == 429
+              # [429] {"error": "too many export requests in progress for this project"}
+              raise RuntimeError.new("[#{response.code}] #{response.body} (will retry)")
+            end
             raise ConfigError.new("[#{response.code}] #{response.body}")
           when 500..599
             raise RuntimeError.new("[#{response.code}] #{response.body}")

--- a/test/embulk/input/mixpanel_api/test_client.rb
+++ b/test/embulk/input/mixpanel_api/test_client.rb
@@ -98,12 +98,30 @@ module Embulk
             end
           end
 
+          def test_retry_for_429_temporary_fail
+            stub_client
+            stub_response(failure_response(429))
+
+            assert_raise(RuntimeError) do
+              @client.export(params)
+            end
+          end
+
           class ExportSmallDataset < self
             def test_to_date_after_1_day
               to = (Date.parse(params["from_date"]) + 1).to_s
               mock(@client).request_small_dataset(params.merge("to_date" => to), Client::SMALLSET_BYTE_RANGE) { [:foo] }
 
               @client.export_for_small_dataset(params)
+            end
+
+            def test_retry_for_429_temporary_fail
+              stub_client
+              stub_response(failure_response(429))
+
+              assert_raise(RuntimeError) do
+                @client.export_for_small_dataset(params)
+              end
             end
 
             def test_to_date_after_1_day_after_10_days_if_empty


### PR DESCRIPTION
Mixpanel API rejects too frequency request from same IP address.
In that situation HTTP status code is 429 (Too Many Request).
It should do retry instead of ConfigError.
