### PR TITLE
Enable realtime data export

### DIFF
--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -82,7 +82,7 @@ module Embulk
         # NOTE: If this plugin supports to run by multi threads, this
         # implementation is terrible.
         task_report = task_reports.first
-        next_to_date = Date.parse(task_report[:to_date]).next
+        next_to_date = Date.parse(task_report[:to_date])
 
         next_config_diff = {from_date: next_to_date.to_s}
         return next_config_diff
@@ -156,7 +156,7 @@ module Embulk
 
         page_builder.finish
 
-        task_report = {to_date: @dates.last || (Date.today - 1)}
+        task_report = {to_date: @dates.last || Date.today}
         return task_report
       end
 

--- a/lib/range_generator.rb
+++ b/lib/range_generator.rb
@@ -9,7 +9,7 @@ class RangeGenerator
   def generate_range
     validate
     show_warnings
-    range_only_past.map{|date| date.to_s}
+    range_only_present.map{|date| date.to_s}
   end
 
   private
@@ -49,12 +49,12 @@ class RangeGenerator
     if fetch_days
       from_date..(from_date + fetch_days - 1)
     else
-      from_date..yesterday
+      from_date..today
     end
   end
 
-  def range_only_past
-    range.find_all{|date| date < today}
+  def range_only_present
+    range.find_all{|date| date <= today}
   end
 
   def overdays?
@@ -62,15 +62,11 @@ class RangeGenerator
   end
 
   def overdays
-    range.to_a - range_only_past.to_a
+    range.to_a - range_only_present.to_a
   end
 
   def from_date_too_early?
-    from_date > yesterday
-  end
-
-  def yesterday
-    today - 1
+    from_date > today
   end
 
   def today

--- a/test/test_range_generator.rb
+++ b/test/test_range_generator.rb
@@ -37,8 +37,8 @@ class RangeGeneratorTest < Test::Unit::TestCase
         @warn_message_regexp = /ignored them/
       end
 
-      def test_range_only_past
-        expected_to = Date.today - 1
+      def test_range_only_present
+        expected_to = Date.today
         expected = (@from..expected_to).to_a.map{|date| date.to_s}
 
         stub(Embulk.logger).warn(@warn_message_regexp)


### PR DESCRIPTION
Mixpanel removed their restriction that ["Generally, the complete data set for the previous day will be available around 6am project time"](https://web.archive.org/web/20150406133607/https://mixpanel.com/docs/api-documentation/exporting-raw-data-you-inserted-into-mixpanel) then ["All data returned from the export API is real-time"](https://mixpanel.com/help/reference/exporting-raw-data#export-api-reference).

This PR enables to load "real-time" data, and implemented de-dup records for the present day specification using Embulk' config_diff.