### PR TITLE
Enable TCP Keepalive to protect from NAT

### DIFF
--- a/embulk-input-mixpanel.gemspec
+++ b/embulk-input-mixpanel.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'httpclient'
+  spec.add_dependency 'httpclient', '>= 2.8.3' # To use tcp_keepalive
   spec.add_dependency 'tzinfo'
   spec.add_dependency 'perfect_retry', ["~> 0.5"]
   spec.add_development_dependency 'bundler', ['~> 1.0']

--- a/lib/embulk/input/mixpanel_api/client.rb
+++ b/lib/embulk/input/mixpanel_api/client.rb
@@ -165,6 +165,7 @@ module Embulk
             begin
               client = HTTPClient.new
               client.receive_timeout = TIMEOUT_SECONDS
+              client.tcp_keepalive = true
               client.default_header = {Accept: "application/json; charset=UTF-8"}
               # client.debug_dev = STDERR
               client

--- a/test/embulk/input/mixpanel_api/test_client.rb
+++ b/test/embulk/input/mixpanel_api/test_client.rb
@@ -30,6 +30,13 @@ module Embulk
           assert_equal(expected, @client.__send__(:signature, params))
         end
 
+        class TestKeepAlive < self
+          def test_tcp_keepalive_enabled
+            client = Client.new(API_KEY, API_SECRET)
+            assert client.send(:httpclient).tcp_keepalive
+          end
+        end
+
         class TryToDatesTest < self
           def setup
             @client = Client.new(API_KEY, API_SECRET)


### PR DESCRIPTION
Sometimes waiting Mixpanel response is a long time enough to be killed by NAT.
This PR enables TCP Keepalive to protect a long time session.