### PR TITLE
Add custom incremental field

### DIFF
--- a/embulk-input-mixpanel.gemspec
+++ b/embulk-input-mixpanel.gemspec
@@ -1,4 +1,3 @@
-
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-mixpanel"
   spec.version       = "0.5.2"

--- a/lib/range_generator.rb
+++ b/lib/range_generator.rb
@@ -47,7 +47,7 @@ class RangeGenerator
     end
 
     if fetch_days
-      from_date..(from_date + fetch_days - 1)
+      from_date..(from_date + (fetch_days > 1? fetch_days - 1 : fetch_days))
     else
       from_date..today
     end

--- a/test/prepare_embulk.rb
+++ b/test/prepare_embulk.rb
@@ -1,6 +1,4 @@
 module PrepareEmbulk
-  require "embulk/command/embulk_run"
-
   if Embulk.respond_to?(:home)
     # keep compatibility for Embulk 0.6.x
     classpath_dir = Embulk.home("classpath")


### PR DESCRIPTION
Add `incremental`, true to run incremental, failed to run one time only, default to true
Add `incremental_column` to choose which column to be added as an incremental condition in where clause, default to nil. This condition will be sent to Mixpanel API.
Add `back_fill_time` to specified how many days we look back for data
