### PR TITLE
Add slice_range configuration

### DIFF
--- a/embulk-input-mixpanel.gemspec
+++ b/embulk-input-mixpanel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-mixpanel"
-  spec.version       = "0.5.4"
+  spec.version       = "0.5.5"
   spec.authors       = ["yoshihara", "uu59"]
   spec.summary       = "Mixpanel input plugin for Embulk"
   spec.description   = "Loads records from Mixpanel."

--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -541,6 +541,7 @@ module Embulk
             retry_initial_wait_sec: 0,
             retry_limit: 3,
             latest_fetched_time: 0,
+            slice_range: 7
           }
         end
       end
@@ -583,6 +584,20 @@ module Embulk
           mock(@page_builder).finish
 
           @plugin.run
+        end
+
+        class SliceRangeRunTest < self
+
+          def test_default_slice_range
+            plugin = Mixpanel.new(task.merge(slice_range: 2), nil, nil, @page_builder)
+            stub(plugin).preview? {false}
+            stub(plugin).fetch(["2015-02-22", "2015-02-23"],0){[]}
+            stub(plugin).fetch(["2015-02-24", "2015-02-25"],0){[]}
+            stub(plugin).fetch(["2015-02-26", "2015-02-27"],0){[]}
+            stub(plugin).fetch(["2015-02-28", "2015-03-01"],0){[]}
+            mock(@page_builder).finish
+            plugin.run
+          end
         end
 
         class NonIncrementalRunTest < self
@@ -807,6 +822,7 @@ module Embulk
           retry_initial_wait_sec: 2,
           retry_limit: 3,
           latest_fetched_time: 0,
+          slice_range: 7
         }
       end
 


### PR DESCRIPTION
Add slice_range configuration. This configuration will control the size of the fetch range.
Example:
```
from_date: 09-01-2017
to_date: 09-07-2017
slice_range: 2
will produce 4 request with the following ranges:
[09-01-2017,09-02-2017]
[09-03-2017,09-04-2017]
[09-05-2017,09-06-2017]
[09-07-2017,09-07-2017]
```