### PR TITLE
Revert rolling range, add fetch limit

### DIFF
--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -160,13 +160,13 @@ module Embulk
         prev_latest_fetched_time = task[:latest_fetched_time] || 0
         prev_latest_fetched_time_format = Time.at(prev_latest_fetched_time).strftime("%F %T %z")
         current_latest_fetched_time = prev_latest_fetched_time
-        @dates.each_slice(task[:slice_range]) do |dates|
+        @dates.each_slice(task[:slice_range]) do |slice_dates|
           ignored_record_count = 0
           unless preview?
-            Embulk.logger.info "Fetching data from #{dates.first} to #{dates.last} ..."
+            Embulk.logger.info "Fetching data from #{slice_dates.first} to #{slice_dates.last} ..."
           end
           record_time_column=@incremental_column || DEFAULT_TIME_COLUMN
-          fetch(dates, prev_latest_fetched_time).each do |record|
+          fetch(slice_dates, prev_latest_fetched_time).each do |record|
             if @incremental
               if !record["properties"].include?(record_time_column)
                 raise Embulk::ConfigError.new("Incremental column not exists in fetched data #{record_time_column}")


### PR DESCRIPTION
Previous fix introduced a more serious issue. So I revert it. The root cause of this issue is that real time data cause conflict and missing data when the job running. So I added a limit to only fetch data with time < than the time the job start to run. This will prevent real time data come in to our query.