### PR TITLE
Limit number of records received to guess or preview

### DIFF
--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -11,7 +11,6 @@ module Embulk
     class Mixpanel < InputPlugin
       Plugin.register_input("mixpanel", self)
 
-      GUESS_RECORDS_COUNT = 10
       NOT_PROPERTY_COLUMN = "event".freeze
 
       # https://mixpanel.com/help/questions/articles/special-or-reserved-properties
@@ -355,7 +354,7 @@ module Embulk
       end
 
       def self.guess_from_records(records)
-        sample_props = records.first(GUESS_RECORDS_COUNT).map {|r| r["properties"]}
+        sample_props = records.map {|r| r["properties"]}
         schema = Guess::SchemaGuess.from_hash_records(sample_props)
         columns = schema.map do |col|
           next if col.name == "time"

--- a/test/embulk/input/mixpanel_api/test_client.rb
+++ b/test/embulk/input/mixpanel_api/test_client.rb
@@ -145,7 +145,7 @@ module Embulk
           class ExportSmallDataset < self
             def test_to_date_after_1_day
               to = (Date.parse(params["from_date"]) + 1).to_s
-              mock(@client).request_small_dataset(params.merge("to_date" => to), Client::SMALLSET_BYTE_RANGE) { [:foo] }
+              mock(@client).request_small_dataset(params.merge("to_date" => to), Client::SMALL_NUM_OF_RECORDS) { [:foo] }
 
               @client.export_for_small_dataset(params)
             end
@@ -163,8 +163,8 @@ module Embulk
               stub_client
               to1 = (Date.parse(params["from_date"]) + 1).to_s
               to2 = (Date.parse(params["from_date"]) + 10).to_s
-              mock(@client).request_small_dataset(params.merge("to_date" => to1), Client::SMALLSET_BYTE_RANGE) { [] }
-              mock(@client).request_small_dataset(params.merge("to_date" => to2), Client::SMALLSET_BYTE_RANGE) { [:foo] }
+              mock(@client).request_small_dataset(params.merge("to_date" => to1), Client::SMALL_NUM_OF_RECORDS) { [] }
+              mock(@client).request_small_dataset(params.merge("to_date" => to2), Client::SMALL_NUM_OF_RECORDS) { [:foo] }
 
               @client.export_for_small_dataset(params)
             end


### PR DESCRIPTION
The previous fetched record limitation was based-on `Range` header but it seems not work really well and it gets full body instead of small sample of records to guess or preview. If there are many records to fetch, that leads plugin downloads huge information as well as consume times to download  and easy to reach timeout of the request.

The PR will update the way to limit number of fetched records by using `limit` parameters and only fetch the sample one hence it will be faster than fetching everything.