### PR TITLE
Use America/Chicago timezone as default for local to get rid of mismatch in days comparison

### DIFF
--- a/test/test_range_generator.rb
+++ b/test/test_range_generator.rb
@@ -5,7 +5,6 @@ require "active_support/core_ext/time"
 class RangeGeneratorTest < Test::Unit::TestCase
   include OverrideAssertRaise
   DEFAULT_TIMEZONE = "America/Chicago"
-  DEFAULT_LOCAL = ActiveSupport::TimeZone["America/Chicago"]
   class GenerateRangeTest < self
     data do
       {
@@ -114,7 +113,7 @@ class RangeGeneratorTest < Test::Unit::TestCase
       RangeGenerator.new(from_date_str, fetch_days, DEFAULT_TIMEZONE).generate_range
     end
     def today
-      DEFAULT_LOCAL.today
+      ActiveSupport::TimeZone[DEFAULT_TIMEZONE].today
     end
   end
 end

--- a/test/test_range_generator.rb
+++ b/test/test_range_generator.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/time"
 class RangeGeneratorTest < Test::Unit::TestCase
   include OverrideAssertRaise
   DEFAULT_TIMEZONE = "America/Chicago"
-  DEFAULT_LOCAL = ActiveSupport::TimeZone["UTC"]
+  DEFAULT_LOCAL = ActiveSupport::TimeZone["America/Chicago"]
   class GenerateRangeTest < self
     data do
       {


### PR DESCRIPTION
**Context:** `test_range_generator.rb` uses 2 difference timezones one for generated its expected days range and another one using function need to test to generated days range. That by chance can lead failure test cases because it could be one timezone passed over new day but another one still in one day before, e.g. `UTC` is 1AM but `America/Chicago` is 5PM. Hence the small fix will use only 1 timezone `America/Chicago`.