### PR TITLE
Replace tzinfo by built-in time to get rid of exception during transition from standard to daylight saving

### DIFF
--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -1,3 +1,4 @@
+require "tzinfo"
 require "perfect_retry"
 require "embulk/input/mixpanel_api/client"
 require "embulk/input/mixpanel_api/exceptions"
@@ -179,7 +180,13 @@ module Embulk
         prev_latest_fetched_time_format = Time.at(prev_latest_fetched_time).strftime("%F %T %z")
         current_latest_fetched_time = prev_latest_fetched_time
         @dates.each_slice(task[:slice_range]) do |slice_dates|
-          ignored_record_count = 0
+          ignored_fetched_record_count = 0
+          # There is the issue with Mixpanel time field during the transition from standard to daylight saving time
+          # in the US timezone i.e. 11 Mar 2018 2AM - 2:59AM, time within that period must not be existed,
+          # due to daylight saving, time will be forwarded 1 hour from 2AM to 3AM.
+          #
+          # All of records with wrong timezone will be ignored instead of throw exception out
+          ignored_wrong_daylight_tz_record_count = 0
           unless preview?
             Embulk.logger.info "Fetching data from #{slice_dates.first} to #{slice_dates.last} ..."
           end
@@ -193,7 +200,7 @@ module Embulk
                 record_time = record["properties"][record_time_column]
                 if @incremental_column.nil?
                   if record_time <= prev_latest_fetched_time
-                    ignored_record_count += 1
+                    ignored_fetched_record_count += 1
                     next
                   end
                 end
@@ -203,15 +210,19 @@ module Embulk
                   record_time,
                 ].max
               end
-              values = extract_values(record)
-              if @fetch_unknown_columns
-                unknown_values = extract_unknown_values(record)
-                values << unknown_values.to_json
+              begin
+                values = extract_values(record)
+                if @fetch_unknown_columns
+                  unknown_values = extract_unknown_values(record)
+                  values << unknown_values.to_json
+                end
+                if task[:fetch_custom_properties]
+                  values << collect_custom_properties(record)
+                end
+                page_builder.add(values)
+              rescue TZInfo::PeriodNotFound
+                ignored_wrong_daylight_tz_record_count += 1
               end
-              if task[:fetch_custom_properties]
-                values << collect_custom_properties(record)
-              end
-              page_builder.add(values)
             end
           rescue MixpanelApi::IncompleteExportResponseError
             if !task[:allow_partial_import]
@@ -219,8 +230,11 @@ module Embulk
               raise
             end
           end
-          if ignored_record_count > 0
-            Embulk.logger.warn "Skipped already loaded #{ignored_record_count} records. These record times are older or equal than previous fetched record time (#{prev_latest_fetched_time} @ #{prev_latest_fetched_time_format})."
+          if ignored_fetched_record_count > 0
+            Embulk.logger.warn "Skipped already loaded #{ignored_fetched_record_count} records. These record times are older or equal than previous fetched record time (#{prev_latest_fetched_time} @ #{prev_latest_fetched_time_format})."
+          end
+          if ignored_wrong_daylight_tz_record_count > 0
+            Embulk.logger.warn "Skipped #{ignored_wrong_daylight_tz_record_count} records due to corrupted Mixpanel time transition from standard to daylight saving"
           end
           break if preview?
         end
@@ -312,7 +326,8 @@ module Embulk
       def adjust_timezone(epoch)
         # Adjust timezone offset to get UTC time
         # c.f. https://mixpanel.com/docs/api-documentation/exporting-raw-data-you-inserted-into-mixpanel#export
-        offset = Time.at(epoch).in_time_zone(@timezone).utc_offset
+        tz = TZInfo::Timezone.get(@timezone)
+        offset = tz.period_for_local(epoch, true).offset.utc_total_offset
         epoch - offset
       end
 

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -1,4 +1,3 @@
-require "tzinfo"
 require "perfect_retry"
 require "embulk/input/mixpanel_api/client"
 require "embulk/input/mixpanel_api/exceptions"
@@ -313,8 +312,7 @@ module Embulk
       def adjust_timezone(epoch)
         # Adjust timezone offset to get UTC time
         # c.f. https://mixpanel.com/docs/api-documentation/exporting-raw-data-you-inserted-into-mixpanel#export
-        tz = TZInfo::Timezone.get(@timezone)
-        offset = tz.period_for_local(epoch, true).offset.utc_offset
+        offset = Time.at(epoch).in_time_zone(@timezone).utc_offset
         epoch - offset
       end
 

--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -797,8 +797,7 @@ module Embulk
             properties = record["properties"]
 
             time = properties["time"]
-            tz = TZInfo::Timezone.get(TIMEZONE)
-            offset = tz.period_for_local(time, true).offset.utc_offset
+            offset = Time.at(time).in_time_zone(TIMEZONE).utc_offset
             adjusted_time = time - offset
 
             added = [

--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -797,7 +797,8 @@ module Embulk
             properties = record["properties"]
 
             time = properties["time"]
-            offset = Time.at(time).in_time_zone(TIMEZONE).utc_offset
+            tz = TZInfo::Timezone.get(TIMEZONE)
+            offset = tz.period_for_local(time, true).offset.utc_offset
             adjusted_time = time - offset
 
             added = [

--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -798,7 +798,7 @@ module Embulk
 
             time = properties["time"]
             tz = TZInfo::Timezone.get(TIMEZONE)
-            offset = tz.period_for_local(time, true).offset.utc_offset
+            offset = tz.period_for_local(time, true).offset.utc_total_offset
             adjusted_time = time - offset
 
             added = [


### PR DESCRIPTION
tzinfo external library: https://github.com/tzinfo/tzinfo has the issue of calculating offset from utc if unix timestamp to calculate stays during the transition from standard time to daylight saving time e.g. 11 Mar 2:00 AM - 11 Mar 3:00 AM, `README` of tzinfo also states that issue.

And also tzinfo does not consider daylight saving time too, that leads data will be wrong during the daylight  saving time.

PR replaced tzinfo by built-in Time which supports calculating offset from utc without any issues with daylight saving time.