### PR TITLE
[Mixpanel][Input] Update the authentication method to latest

### DIFF
--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -61,7 +61,6 @@ module Embulk
           dates: range,
           timezone: timezone,
           export_endpoint: export_endpoint(config),
-          api_key: config.param(:api_key, :string),
           api_secret: config.param(:api_secret, :string),
           schema: config.param(:columns, :array),
           fetch_unknown_columns: fetch_unknown_columns,
@@ -129,8 +128,7 @@ module Embulk
           retry_initial_wait_sec: config.param(:retry_initial_wait_sec, :integer, default: 1),
           retry_limit: config.param(:retry_limit, :integer, default: 5),
         })
-        client = MixpanelApi::Client.new(config.param(:api_key, :string),
-                                         config.param(:api_secret, :string),
+        client = MixpanelApi::Client.new(config.param(:api_secret, :string),
                                          retryer,
                                          export_endpoint(config))
 
@@ -162,7 +160,6 @@ module Embulk
 
       def init
         @export_endpoint = task[:export_endpoint]
-        @api_key = task[:api_key]
         @api_secret = task[:api_secret]
         @params = task[:params]
         @timezone = task[:timezone]
@@ -310,7 +307,7 @@ module Embulk
           )
         end
         Embulk.logger.info "Where params is #{params["where"]}"
-        client = MixpanelApi::Client.new(@api_key, @api_secret, self.class.perfect_retry(task), @export_endpoint)
+        client = MixpanelApi::Client.new(@api_secret, self.class.perfect_retry(task), @export_endpoint)
 
         if preview?
           client.export_for_small_dataset(params)
@@ -342,9 +339,7 @@ module Embulk
       def self.export_params(config)
         event = config.param(:event, :array, default: nil)
         event = event.nil? ? nil : event.to_json
-
         {
-          api_key: config.param(:api_key, :string),
           event: event,
           where: config.param(:where, :string, default: nil),
           bucket: config.param(:bucket, :string, default: nil),

--- a/test/embulk/input/mixpanel_api/test_client.rb
+++ b/test/embulk/input/mixpanel_api/test_client.rb
@@ -8,39 +8,23 @@ module Embulk
       class ClientTest < Test::Unit::TestCase
         include OverrideAssertRaise
 
-        API_KEY = "api_key".freeze
         API_SECRET = "api_secret".freeze
 
         def setup
-          @client = Client.new(API_KEY, API_SECRET)
+          @client = Client.new(API_SECRET)
           stub(Embulk).logger { ::Logger.new(IO::NULL) }
-        end
-
-        # NOTE: Client#signature is private method but this value
-        # can't be checked via other methods.
-        def test_signature
-          now = Time.parse("2015-07-22 00:00:00")
-          stub(Time).now { now }
-
-          params = {
-            string: "string",
-            array: ["elem1", "elem2"],
-          }
-          expected = "4be4a4f92f57e12b543a2a5f2f5897b6"
-
-          assert_equal(expected, @client.__send__(:signature, params))
         end
 
         class TestKeepAlive < self
           def test_tcp_keepalive_enabled
-            client = Client.new(API_KEY, API_SECRET)
+            client = Client.new(API_SECRET)
             assert client.send(:httpclient).tcp_keepalive
           end
         end
 
         class TryToDatesTest < self
           def setup
-            @client = Client.new(API_KEY, API_SECRET)
+            @client = Client.new(API_SECRET)
           end
 
           data do
@@ -77,7 +61,7 @@ module Embulk
 
           def test_success
             stub_client
-            stub(@client).set_signatures(anything) {}
+            # stub(@client).set_signatures(anything) {}
             stub_response(success_response)
 
             records = []
@@ -90,7 +74,7 @@ module Embulk
 
           def test_export_partial_with_export_terminated_early
             stub_client
-            stub(@client).set_signatures(anything) {}
+            # stub(@client).set_signatures(anything) {}
             stub_response(Struct.new(:code, :body).new(200, jsonl_dummy_responses+"\nexport terminated early"))
 
             records = []
@@ -104,7 +88,7 @@ module Embulk
 
           def test_export_partial_with_error_json
             stub_client
-            stub(@client).set_signatures(anything) {}
+            # stub(@client).set_signatures(anything) {}
             stub_response(Struct.new(:code, :body).new(200, jsonl_dummy_responses+"\n{\"error\":"))
             records = []
             assert_raise MixpanelApi::IncompleteExportResponseError do
@@ -203,7 +187,6 @@ module Embulk
 
           def params
             {
-              "api_key" => API_KEY,
               "api_secret" => API_SECRET,
               "from_date" => "2015-01-01",
               "to_date" => "2015-03-02",

--- a/test/embulk/input/mixpanel_api/test_client.rb
+++ b/test/embulk/input/mixpanel_api/test_client.rb
@@ -27,14 +27,9 @@ module Embulk
             @client = Client.new(API_SECRET)
           end
 
-          data do
-            [
-              ["2000-01-01", "2000-01-01"],
-              ["2010-01-01", "2010-01-01"],
-              ["3 days ago", (Date.today - 3).to_s],
-            ]
-          end
-          def test_candidates(from_str)
+
+          def test_candidates_case1
+            from_str = "2000-01-01"
             from = Date.parse(from_str)
             yesterday = Date.today - 1
             dates = @client.try_to_dates(from.to_s)
@@ -45,6 +40,24 @@ module Embulk
               from + 1000,
               from + 10000,
               yesterday,
+            ].find_all{|d| d <= yesterday}
+
+            assert_equal expect, dates
+            assert dates.all?{|d| d <= yesterday}
+          end
+
+          def test_candidates_case2
+            from_str = (Date.today - 3).to_s
+            from = Date.parse(from_str)
+            yesterday = Date.today - 1
+            dates = @client.try_to_dates(from.to_s)
+            expect = [
+                from + 1,
+                from + 10,
+                from + 100,
+                from + 1000,
+                from + 10000,
+                yesterday,
             ].find_all{|d| d <= yesterday}
 
             assert_equal expect, dates

--- a/test/embulk/input/test_mixpanel.rb
+++ b/test/embulk/input/test_mixpanel.rb
@@ -9,7 +9,6 @@ module Embulk
     class MixpanelTest < Test::Unit::TestCase
       include OverrideAssertRaise
 
-      API_KEY = "api_key".freeze
       API_SECRET = "api_secret".freeze
       FROM_DATE = "2015-02-22".freeze
       TO_DATE = "2015-03-02".freeze
@@ -31,7 +30,6 @@ module Embulk
 
       def setup_client
         params = {
-          api_key: API_KEY,
           event: nil,
           where: nil,
           bucket: nil,
@@ -72,7 +70,6 @@ module Embulk
         def test_from_date_old_date
           config = {
             type: "mixpanel",
-            api_key: API_KEY,
             api_secret: API_SECRET,
             from_date: FROM_DATE,
           }
@@ -87,7 +84,6 @@ module Embulk
         def test_from_date_future
           config = {
             type: "mixpanel",
-            api_key: API_KEY,
             api_secret: API_SECRET,
             timezone: TIMEZONE,
             from_date: (today + 1).to_s
@@ -103,7 +99,6 @@ module Embulk
           from_date = (today - 1).to_s
           config = {
             type: "mixpanel",
-            api_key: API_KEY,
             api_secret: API_SECRET,
             from_date: from_date,
           }
@@ -117,7 +112,6 @@ module Embulk
         def test_no_from_date
           config = {
             type: "mixpanel",
-            api_key: API_KEY,
             api_secret: API_SECRET,
             timezone: TIMEZONE
           }
@@ -141,7 +135,6 @@ module Embulk
           stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? { false }
           config = {
             type: "mixpanel",
-            api_key: API_KEY,
             api_secret: API_SECRET,
           }
 
@@ -300,7 +293,6 @@ module Embulk
           def transaction_task(timezone)
             task.merge(
               dates: DATES.map {|date| date.to_s},
-              api_key: API_KEY,
               api_secret: API_SECRET,
               incremental: true,
               incremental_column: nil,
@@ -366,7 +358,6 @@ module Embulk
             from_date = Date.parse(FROM_DATE)
             task.merge(
               dates: (from_date..(from_date + days - 1)).map {|date| date.to_s},
-              api_key: API_KEY,
               api_secret: API_SECRET,
               timezone: TIMEZONE,
               schema: schema
@@ -434,7 +425,6 @@ module Embulk
         def transaction_task
           task.merge(
             dates: DATES.map {|date| date.to_s},
-            api_key: API_KEY,
             api_secret: API_SECRET,
             timezone: TIMEZONE,
             schema: schema
@@ -451,7 +441,6 @@ module Embulk
       def test_export_params
         config_params = [
           :type, "mixpanel",
-          :api_key, API_KEY,
           :api_secret, API_SECRET,
           :from_date, FROM_DATE,
           :to_date, TO_DATE,
@@ -463,7 +452,6 @@ module Embulk
         config = DataSource[*config_params]
 
         expected = {
-          api_key: API_KEY,
           event: "[\"ViewHoge\",\"ViewFuga\"]",
           where: 'properties["$os"] == "Windows"',
           bucket: "987",
@@ -541,7 +529,6 @@ module Embulk
 
         def task
           {
-            api_key: API_KEY,
             api_secret: API_SECRET,
             export_endpoint: "https://data.mixpanel.com/api/2.0/export/",
             timezone: TIMEZONE,
@@ -846,7 +833,6 @@ module Embulk
 
       def task
         {
-          api_key: API_KEY,
           api_secret: API_SECRET,
           export_endpoint: "https://data.mixpanel.com/api/2.0/export/",
           timezone: TIMEZONE,
@@ -891,7 +877,6 @@ module Embulk
       def config
         {
           type: "mixpanel",
-          api_key: API_KEY,
           api_secret: API_SECRET,
           from_date: FROM_DATE,
           fetch_days: DAYS,


### PR DESCRIPTION
Our current Mixpanel plugin uses API key and secret with basic authentication to sign in. It is still working for client.
However, the Mixpanel doc declares the mechanism as deprecated

Instead of using api_key + api_secret, we now only need api_secret for authentication.