### PR TITLE
Release 0.5.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 
-jdk: oraclejdk8
+dist: trusty
+
+jdk: openjdk8
+
 sudo: false
 
 addons:
@@ -15,9 +18,9 @@ before_install:
     ruby -v
     rvm get head
     rvm use jruby-9.0.5.0 --install
-    gem install bundler
+    gem install bundler -v '< 2'
     ruby -v
-  - gem i bundler
+  - gem install bundler -v '< 2'
 
 rvm:
   - jruby-9.0.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.15 - 2020-01-22
+
+* [enhancement] Update the authentication method to latest [#63](https://github.com/treasure-data/embulk-input-mixpanel/pull/63)
+
 ## 0.5.14 - 2018-10-22
 
 * [enhancement] Handle the wrong period during transition from standard to daylight saving time exception [#62](https://github.com/treasure-data/embulk-input-mixpanel/pull/62)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ To get it, you should log in mixpanel website, and click gear icon at the lower 
 
 ### Configuration
 
-- **api_key**: project API Key (string, required)
 - **api_secret**: project API Secret (string, required)
 - **export_endpoint**: the Data Export API's endpoint (string, default to "http://data.mixpanel.com/api/2.0/export")
 - **timezone**: project timezone(string, required)
@@ -69,7 +68,6 @@ If you have such data and set config.yml as below.
 ```yaml
 in:
   type: mixpanel
-  api_key: "API_KEY"
   api_secret: "API_SECRET"
   timezone: "US/Pacific"
   from_date: "2015-07-19"
@@ -102,7 +100,6 @@ in:
 ```yaml
 in:
   type: mixpanel
-  api_key: "API_KEY"
   api_secret: "API_SECRET"
   timezone: "US/Pacific"
   from_date: "2015-07-19"

--- a/embulk-input-mixpanel.gemspec
+++ b/embulk-input-mixpanel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-mixpanel"
-  spec.version       = "0.5.14"
+  spec.version       = "0.5.15"
   spec.authors       = ["yoshihara", "uu59"]
   spec.summary       = "Mixpanel input plugin for Embulk"
   spec.description   = "Loads records from Mixpanel."
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'httpclient', '>= 2.8.3' # To use tcp_keepalive
-  spec.add_dependency 'tzinfo'
+  spec.add_dependency 'tzinfo', '1.2.5'
   spec.add_dependency 'perfect_retry', ["~> 0.5"]
   spec.add_dependency 'activesupport'
   spec.add_development_dependency 'bundler', ['~> 1.0']

--- a/embulk-input-mixpanel.gemspec
+++ b/embulk-input-mixpanel.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'httpclient', '>= 2.8.3' # To use tcp_keepalive
-  spec.add_dependency 'tzinfo', '1.2.5'
+  spec.add_dependency 'tzinfo', '1.2.5' # to avoid failure in when upgrade to 1.2.6 https://github.com/tzinfo/tzinfo/issues/114
   spec.add_dependency 'perfect_retry', ["~> 0.5"]
   spec.add_dependency 'activesupport'
   spec.add_development_dependency 'bundler', ['~> 1.0']


### PR DESCRIPTION
Release 0.5.15
specify version `1.2.5` to `tzinfo` to avoid changes in `1.2.6` causes fail in UT. 
More information:
https://travis-ci.org/treasure-data/embulk-input-mixpanel/jobs/638469421

```
/home/travis/build/treasure-data/embulk-input-mixpanel/test/test_range_generator.rb:40:in `test_1_fetch_day'
/home/travis/build/treasure-data/embulk-input-mixpanel/lib/range_generator.rb:14:in `generate_range'
/home/travis/build/treasure-data/embulk-input-mixpanel/lib/range_generator.rb:38:in `show_warnings'
/home/travis/build/treasure-data/embulk-input-mixpanel/lib/range_generator.rb:72:in `from_date_too_early?'
/home/travis/build/treasure-data/embulk-input-mixpanel/lib/range_generator.rb:76:in `today'
/home/travis/.rvm/gems/jruby-9.0.5.0/gems/activesupport-5.2.4.1/lib/active_support/values/time_zone.rb:234:in `[]'
/home/travis/.rvm/gems/jruby-9.0.5.0/gems/activesupport-5.2.4.1/lib/active_support/values/time_zone.rb:300:in `initialize'
/home/travis/.rvm/gems/jruby-9.0.5.0/gems/activesupport-5.2.4.1/lib/active_support/values/time_zone.rb:206:in `find_tzinfo'
/home/travis/.rvm/gems/jruby-9.0.5.0/gems/tzinfo-1.2.6/lib/tzinfo/timezone.rb:113:in `new'
/home/travis/.rvm/gems/jruby-9.0.5.0/gems/tzinfo-1.2.6/lib/tzinfo/timezone.rb:92:in `get'
/home/travis/.rvm/gems/jruby-9.0.5.0/gems/tzinfo-1.2.6/lib/tzinfo/zoneinfo_data_source.rb:211:in `load_timezone_info'
/home/travis/.rvm/gems/jruby-9.0.5.0/gems/tzinfo-1.2.6/lib/tzinfo/zoneinfo_timezone_info.rb:29:in `initialize'
Error: test_1_fetch_day(RangeGeneratorTest::GenerateRangeTest): ArgumentError: wrong number of arguments (0 for 1)
```

The syntax failure could be the jruby issue, issue itself I filed in `tzinfo`: https://github.com/tzinfo/tzinfo/issues/114