### PR TITLE
Support jql query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0 - 2020-03-30
+
+* [enhancement] Support JQL script [#65](https://github.com/treasure-data/embulk-input-mixpanel/pull/65)
+
 ## 0.5.15 - 2020-01-22
 
 * [enhancement] Update the authentication method to latest [#63](https://github.com/treasure-data/embulk-input-mixpanel/pull/63)

--- a/embulk-input-mixpanel.gemspec
+++ b/embulk-input-mixpanel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-mixpanel"
-  spec.version       = "0.5.15"
+  spec.version       = "0.5.16.alpha.1"
   spec.authors       = ["yoshihara", "uu59"]
   spec.summary       = "Mixpanel input plugin for Embulk"
   spec.description   = "Loads records from Mixpanel."

--- a/embulk-input-mixpanel.gemspec
+++ b/embulk-input-mixpanel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-mixpanel"
-  spec.version       = "0.5.16.alpha.1"
+  spec.version       = "0.5.16.alpha.2"
   spec.authors       = ["yoshihara", "uu59"]
   spec.summary       = "Mixpanel input plugin for Embulk"
   spec.description   = "Loads records from Mixpanel."

--- a/embulk-input-mixpanel.gemspec
+++ b/embulk-input-mixpanel.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "embulk-input-mixpanel"
-  spec.version       = "0.5.16.alpha.2"
+  spec.version       = "0.6.0"
   spec.authors       = ["yoshihara", "uu59"]
   spec.summary       = "Mixpanel input plugin for Embulk"
   spec.description   = "Loads records from Mixpanel."

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -39,8 +39,8 @@ module Embulk
         if task[:incremental]
           task_report = task_reports.first
           service = service(task)
-          next_config_diff = service.create_next_config_diff(task_report)
-          return next_config_diff
+          next_from_date = service.next_from_date(task_report)
+          return next_from_date
         end
         return {}
       end
@@ -52,7 +52,6 @@ module Embulk
       end
 
       def init
-        @export_endpoint = task[:export_endpoint]
         @api_secret = task[:api_secret]
       end
 

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -1,6 +1,5 @@
 require "embulk/input/service/jql_service"
 require "embulk/input/service/export_service"
-require "pry"
 
 module Embulk
   module Input
@@ -11,6 +10,7 @@ module Embulk
         service = service(config)
         service.validate_config
         task = service.create_task
+        Embulk.logger.info "Try to fetch data from #{task[:dates].first} to #{task[:dates].last}"
 
         columns = task[:schema].map do |column|
           name = column["name"]
@@ -57,8 +57,7 @@ module Embulk
       end
 
       def run
-
-        Mixpanel::service(task).ingest(task, page_builder)
+        Mixpanel::service(DataSource[task.to_a]).ingest(task, page_builder)
       end
 
       private

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -1,88 +1,17 @@
-require "tzinfo"
-require "perfect_retry"
-require "embulk/input/mixpanel_api/client"
-require "embulk/input/mixpanel_api/exceptions"
-require "range_generator"
-require "timezone_validator"
-require "active_support/core_ext/time"
+require "embulk/input/service/jql_service"
+require "embulk/input/service/export_service"
 
 module Embulk
   module Input
     class Mixpanel < InputPlugin
       Plugin.register_input("mixpanel", self)
 
-      NOT_PROPERTY_COLUMN = "event".freeze
-
-      # https://mixpanel.com/help/questions/articles/special-or-reserved-properties
-      # https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default
-      #
-      # JavaScript to extract key names from HTML: run it on Chrome Devtool when opening their document
-      # > Array.from(document.querySelectorAll("strong")).map(function(s){ return s.textContent.match(/[A-Z]/) ? s.parentNode.textContent.match(/\((.*?)\)/)[1] : s.textContent.split(",").join(" ") }).join(" ")
-      # > Array.from(document.querySelectorAll("li")).map(function(s){ m = s.textContent.match(/\((.*?)\)/); return m && m[1] }).filter(function(k) { return k && !k.match("utm") }).join(" ")
-      KNOWN_KEYS = %W(
-        #{NOT_PROPERTY_COLUMN}
-        distinct_id ip mp_name_tag mp_note token time mp_country_code length campaign_id $email $phone $distinct_id $ios_devices $android_devices $first_name  $last_name  $name $city $region $country_code $timezone $unsubscribed
-        $city $region mp_country_code $browser $browser_version $device $current_url $initial_referrer $initial_referring_domain $os $referrer $referring_domain $screen_height $screen_width $search_engine $city $region $mp_country_code $timezone $browser_version $browser $initial_referrer $initial_referring_domain $os $last_seen $city $region mp_country_code $app_release $app_version $carrier $ios_ifa $os_version $manufacturer $lib_version $model $os $screen_height $screen_width $wifi $city $region $mp_country_code $timezone $ios_app_release $ios_app_version $ios_device_model $ios_lib_version $ios_version $ios_ifa $last_seen $city $region mp_country_code $app_version $bluetooth_enabled $bluetooth_version $brand $carrier $has_nfc $has_telephone $lib_version $manufacturer $model $os $os_version $screen_dpi $screen_height $screen_width $wifi $google_play_services $city $region mp_country_code $timezone $android_app_version $android_app_version_code $android_lib_version $android_os $android_os_version $android_brand $android_model $android_manufacturer $last_seen
-      ).uniq.freeze
-
-
-      DEFAULT_FETCH_DAYS = 7
-      DEFAULT_TIME_COLUMN = 'time'
-
+      @@service = nil
       def self.transaction(config, &control)
-        timezone = config.param(:timezone, :string)
-        TimezoneValidator.new(timezone).validate
-
-        from_date = config.param(:from_date, :string, default: (today(timezone) - 2).to_s)
-        fetch_days = config.param(:fetch_days, :integer, default: nil)
-
-
-        fetch_unknown_columns = config.param(:fetch_unknown_columns, :bool, default: false)
-
-        incremental_column = config.param(:incremental_column, :string, default: nil)
-        incremental = config.param(:incremental, :bool, default: true)
-        latest_fetched_time = config.param(:latest_fetched_time, :integer, default: 0)
-
-        # Backfill from date if incremental and an incremental field is set and we are in incremental run
-        if incremental && incremental_column && latest_fetched_time !=0
-          back_fill_days = config.param(:back_fill_days, :integer, default: 5)
-          Embulk.logger.info "Backfill days #{back_fill_days}"
-          from_date = (Date.parse(from_date) - back_fill_days).to_s
-          fetch_days = fetch_days.nil? ? nil : fetch_days + back_fill_days
-        end
-
-        range = RangeGenerator.new(from_date, fetch_days, timezone).generate_range
-        Embulk.logger.info "Try to fetch data from #{range.first} to #{range.last}"
-        job_start_time = Time.now.to_i*1000
-        upper_limit_delay = config.param(:incremental_column_upper_limit_delay_in_seconds, :integer, default: 0)
-        incremental_column_upper_limit = job_start_time - (upper_limit_delay * 1000)
-        task = {
-          params: export_params(config),
-          dates: range,
-          timezone: timezone,
-          export_endpoint: export_endpoint(config),
-          api_secret: config.param(:api_secret, :string),
-          schema: config.param(:columns, :array),
-          fetch_unknown_columns: fetch_unknown_columns,
-          fetch_custom_properties: config.param(:fetch_custom_properties, :bool, default: true),
-          retry_initial_wait_sec: config.param(:retry_initial_wait_sec, :integer, default: 1),
-          incremental_column: incremental_column,
-          retry_limit: config.param(:retry_limit, :integer, default: 5),
-          latest_fetched_time: latest_fetched_time,
-          incremental: incremental,
-          slice_range: config.param(:slice_range, :integer, default: 7),
-          job_start_time: job_start_time,
-          incremental_column_upper_limit: incremental_column_upper_limit,
-          allow_partial_import: config.param(:allow_partial_import,:bool, default: true)
-        }
-
-        if !incremental_column.nil? && !latest_fetched_time.nil? && (incremental_column_upper_limit <= latest_fetched_time)
-            raise Embulk::ConfigError.new("Incremental column upper limit (job_start_time - incremental_column_upper_limit_delay_in_seconds) can't be smaller or equal latest fetched time #{latest_fetched_time}")
-        end
-
-        if task[:fetch_unknown_columns] && task[:fetch_custom_properties]
-          raise Embulk::ConfigError.new("Don't set true both `fetch_unknown_columns` and `fetch_custom_properties`.")
-        end
+        @@service = service(config)
+        @@service.validate_config
+        task = @@service.create_task
+        Embulk.logger.info "Try to fetch data from #{task[:dates].first} to #{task[:dates].last}"
 
         columns = task[:schema].map do |column|
           name = column["name"]
@@ -91,13 +20,13 @@ module Embulk
           Column.new(nil, name, type, column["format"])
         end
 
-        if fetch_unknown_columns
-          Embulk.logger.warn "Deprecated `unknown_columns`. Use `fetch_custom_properties` instead."
-          columns << Column.new(nil, "unknown_columns", :json)
-        end
-
         if task[:fetch_custom_properties]
           columns << Column.new(nil, "custom_properties", :json)
+        end
+
+        if task[:fetch_unknown_columns]
+          Embulk.logger.warn "Deprecated `unknown_columns`. Use `fetch_custom_properties` instead."
+          columns << Column.new(nil, "unknown_columns", :json)
         end
 
         resume(task, columns, 1, &control)
@@ -110,283 +39,41 @@ module Embulk
         # implementation is terrible.
         if task[:incremental]
           task_report = task_reports.first
-          next_to_date = Date.parse(task_report[:to_date])
-
-          next_config_diff = {
-            from_date: next_to_date.to_s,
-            latest_fetched_time: task_report[:latest_fetched_time],
-          }
+          next_config_diff = @@service.create_next_config_diff(task_report)
           return next_config_diff
         end
         return {}
       end
 
       def self.guess(config)
-        giveup_when_mixpanel_is_down(export_endpoint(config))
-
-        retryer = perfect_retry({
-          retry_initial_wait_sec: config.param(:retry_initial_wait_sec, :integer, default: 1),
-          retry_limit: config.param(:retry_limit, :integer, default: 5),
-        })
-        client = MixpanelApi::Client.new(config.param(:api_secret, :string),
-                                         retryer,
-                                         export_endpoint(config))
-
-        range = guess_range(config)
-        Embulk.logger.info "Guessing schema using #{range.first}..#{range.last} records"
-
-        params = export_params(config).merge(
-          "from_date" => range.first,
-          "to_date" => range.last,
-        )
-        columns = guess_from_records(client.export_for_small_dataset(params))
-        return {"columns" => columns}
-      end
-
-      def self.perfect_retry(task)
-        PerfectRetry.new do |config|
-          config.limit = task[:retry_limit]
-          config.sleep = proc{|n| task[:retry_initial_wait_sec] * (2 * (n - 1)) }
-          config.dont_rescues = [Embulk::ConfigError,MixpanelApi::IncompleteExportResponseError]
-          config.rescues = [RuntimeError]
-          config.log_level = nil
-          config.logger = Embulk.logger
-        end
-      end
-
-      def self.export_endpoint(config)
-        config.param(:export_endpoint, :string, default: Embulk::Input::MixpanelApi::Client::DEFAULT_EXPORT_ENDPOINT)
+        @@service = service(config)
+        @@service.validate_config
+        return {"columns" => @@service.guess_columns}
       end
 
       def init
         @export_endpoint = task[:export_endpoint]
         @api_secret = task[:api_secret]
-        @params = task[:params]
-        @timezone = task[:timezone]
-        @schema = task[:schema]
-        @dates = task[:dates]
-        @fetch_unknown_columns = task[:fetch_unknown_columns]
-        @incremental_column = task[:incremental_column]
-        @incremental = task[:incremental]
       end
 
       def run
-        Embulk.logger.info "Job start time is #{task[:job_start_time]}"
-        self.class.giveup_when_mixpanel_is_down(task[:export_endpoint])
-        prev_latest_fetched_time = task[:latest_fetched_time] || 0
-        prev_latest_fetched_time_format = Time.at(prev_latest_fetched_time).strftime("%F %T %z")
-        current_latest_fetched_time = prev_latest_fetched_time
-        @dates.each_slice(task[:slice_range]) do |slice_dates|
-          ignored_fetched_record_count = 0
-          # There is the issue with Mixpanel time field during the transition from standard to daylight saving time
-          # in the US timezone i.e. 11 Mar 2018 2AM - 2:59AM, time within that period must not be existed,
-          # due to daylight saving, time will be forwarded 1 hour from 2AM to 3AM.
-          #
-          # All of records with wrong timezone will be ignored instead of throw exception out
-          ignored_wrong_daylight_tz_record_count = 0
-          unless preview?
-            Embulk.logger.info "Fetching data from #{slice_dates.first} to #{slice_dates.last} ..."
-          end
-          record_time_column=@incremental_column || DEFAULT_TIME_COLUMN
-          begin
-            fetch(slice_dates, prev_latest_fetched_time).each do |record|
-              if @incremental
-                if !record["properties"].include?(record_time_column)
-                  raise Embulk::ConfigError.new("Incremental column not exists in fetched data #{record_time_column}")
-                end
-                record_time = record["properties"][record_time_column]
-                if @incremental_column.nil?
-                  if record_time <= prev_latest_fetched_time
-                    ignored_fetched_record_count += 1
-                    next
-                  end
-                end
-
-                current_latest_fetched_time= [
-                  current_latest_fetched_time,
-                  record_time,
-                ].max
-              end
-              begin
-                values = extract_values(record)
-                if @fetch_unknown_columns
-                  unknown_values = extract_unknown_values(record)
-                  values << unknown_values.to_json
-                end
-                if task[:fetch_custom_properties]
-                  values << collect_custom_properties(record)
-                end
-                page_builder.add(values)
-              rescue TZInfo::PeriodNotFound
-                ignored_wrong_daylight_tz_record_count += 1
-              end
-            end
-          rescue MixpanelApi::IncompleteExportResponseError
-            if !task[:allow_partial_import]
-            #   re raise the exception if we don't allow partial import
-              raise
-            end
-          end
-          if ignored_fetched_record_count > 0
-            Embulk.logger.warn "Skipped already loaded #{ignored_fetched_record_count} records. These record times are older or equal than previous fetched record time (#{prev_latest_fetched_time} @ #{prev_latest_fetched_time_format})."
-          end
-          if ignored_wrong_daylight_tz_record_count > 0
-            Embulk.logger.warn "Skipped #{ignored_wrong_daylight_tz_record_count} records due to corrupted Mixpanel time transition from standard to daylight saving"
-          end
-          break if preview?
-        end
-        page_builder.finish
-        task_report = {
-          latest_fetched_time: current_latest_fetched_time,
-          to_date: @dates.last || today(@timezone) - 1,
-        }
-        task_report
+        @@service.ingest(task, page_builder)
       end
 
       private
 
-      def self.giveup_when_mixpanel_is_down(export_endpoint)
-        unless MixpanelApi::Client.mixpanel_available?(export_endpoint)
-          raise Embulk::DataError.new("Mixpanel service is down. Please retry later.")
-        end
-      end
-
-      def extract_values(record)
-        @schema.map do |column|
-          extract_value(record, column["name"])
-        end
-      end
-
-      def extract_value(record, name)
-        case name
-        when NOT_PROPERTY_COLUMN
-          record[NOT_PROPERTY_COLUMN]
-        when "time"
-          time = record["properties"]["time"]
-          adjust_timezone(time)
+      def self.service(config)
+        if @@service.present?
+          @@service
         else
-          record["properties"][name]
-        end
-      end
-
-      def collect_custom_properties(record)
-        specified_columns = @schema.map{|col| col["name"]}
-        custom_keys = record["properties"].keys.find_all{|key| !KNOWN_KEYS.include?(key.to_s) && !specified_columns.include?(key.to_s) }
-        custom_keys.inject({}) do |result, key|
-          result.merge({
-            key => record["properties"][key]
-          })
-        end
-      end
-
-      def extract_unknown_values(record)
-        record_keys = record["properties"].keys + [NOT_PROPERTY_COLUMN]
-        schema_keys = @schema.map {|column| column["name"]}
-        unknown_keys = record_keys - schema_keys
-
-        unless unknown_keys.empty?
-          Embulk.logger.warn("Unknown columns exists in record: #{unknown_keys.join(', ')}")
-        end
-
-        unknown_keys.inject({}) do |result, key|
-          result[key] = extract_value(record, key)
-          result
-        end
-      end
-
-      def fetch(dates, last_fetch_time, &block)
-        from_date = dates.first
-        to_date = dates.last
-        params = @params.merge(
-          "from_date" => from_date,
-          "to_date" => to_date
-        )
-        if !@incremental_column.nil? # can't do filter on time column, time column need to be filter manually.
-          params = params.merge(
-            "where" => "#{params['where'].nil? ? '' : "(#{params['where']}) and " }properties[\"#{@incremental_column}\"] > #{last_fetch_time || 0} and properties[\"#{@incremental_column}\"] < #{task[:incremental_column_upper_limit]}"
-          )
-        end
-        Embulk.logger.info "Where params is #{params["where"]}"
-        client = MixpanelApi::Client.new(@api_secret, self.class.perfect_retry(task), @export_endpoint)
-
-        if preview?
-          client.export_for_small_dataset(params)
-        else
-          Enumerator.new do |y|
-            client.export(params) do |record|
-              y << record
-            end
+          jql_mode = config.param(:jql_mode, :bool, default: false)
+          if jql_mode
+            Service::JqlService.new(config)
+          else
+            Service::ExportService.new(config)
           end
         end
       end
-
-      def adjust_timezone(epoch)
-        # Adjust timezone offset to get UTC time
-        # c.f. https://mixpanel.com/docs/api-documentation/exporting-raw-data-you-inserted-into-mixpanel#export
-        tz = TZInfo::Timezone.get(@timezone)
-        offset = tz.period_for_local(epoch, true).offset.utc_total_offset
-        epoch - offset
-      end
-
-      def preview?
-        begin
-          org.embulk.spi.Exec.isPreview()
-        rescue java.lang.NullPointerException => e
-          false
-        end
-      end
-
-      def self.export_params(config)
-        event = config.param(:event, :array, default: nil)
-        event = event.nil? ? nil : event.to_json
-        {
-          event: event,
-          where: config.param(:where, :string, default: nil),
-          bucket: config.param(:bucket, :string, default: nil),
-        }
-      end
-
-      def self.default_guess_start_date(timezone)
-        today(timezone) - DEFAULT_FETCH_DAYS - 1
-      end
-
-      def self.guess_range(config)
-        time_zone = config.param(:timezone, :string, default: "")
-        from_date = config.param(:from_date, :string, default: default_guess_start_date(time_zone).to_s)
-        fetch_days = config.param(:fetch_days, :integer, default: DEFAULT_FETCH_DAYS)
-        range = RangeGenerator.new(from_date, fetch_days, time_zone).generate_range
-        if range.empty?
-          return default_guess_start_date(time_zone)..(today(time_zone) - 1)
-        end
-        range
-      end
-
-      def self.guess_from_records(records)
-        sample_props = records.map {|r| r["properties"]}
-        schema = Guess::SchemaGuess.from_hash_records(sample_props)
-        columns = schema.map do |col|
-          next if col.name == "time"
-          result = {
-            name: col.name,
-            type: col.type,
-          }
-          result[:format] = col.format if col.format
-          result
-        end.compact
-        columns.unshift(name: NOT_PROPERTY_COLUMN, type: :string)
-        # Shift incremental column to top
-        columns.unshift(name: "time", type: :long)
-      end
-
-      def self.today(timezone)
-        if timezone.nil?
-          Date.today
-        else
-          zone = ActiveSupport::TimeZone[timezone]
-          zone.nil? ? Date.today : zone.today
-        end
-      end
-
     end
   end
 end

--- a/lib/embulk/input/mixpanel.rb
+++ b/lib/embulk/input/mixpanel.rb
@@ -7,6 +7,7 @@ module Embulk
       Plugin.register_input("mixpanel", self)
 
       @@service = nil
+
       def self.transaction(config, &control)
         @@service = service(config)
         @@service.validate_config
@@ -48,7 +49,7 @@ module Embulk
       def self.guess(config)
         @@service = service(config)
         @@service.validate_config
-        return {"columns" => @@service.guess_columns}
+        return {"columns"=>@@service.guess_columns}
       end
 
       def init
@@ -63,15 +64,11 @@ module Embulk
       private
 
       def self.service(config)
-        if @@service.present?
-          @@service
+        jql_mode = config.param(:jql_mode, :bool, default: false)
+        if jql_mode
+          Service::JqlService.new(config)
         else
-          jql_mode = config.param(:jql_mode, :bool, default: false)
-          if jql_mode
-            Service::JqlService.new(config)
-          else
-            Service::ExportService.new(config)
-          end
+          Service::ExportService.new(config)
         end
       end
     end

--- a/lib/embulk/input/mixpanel_api/client.rb
+++ b/lib/embulk/input/mixpanel_api/client.rb
@@ -3,7 +3,6 @@ require "digest/md5"
 require "json"
 require "httpclient"
 require "embulk/input/mixpanel_api/exceptions"
-require 'pry'
 
 module Embulk
   module Input

--- a/lib/embulk/input/mixpanel_api/client.rb
+++ b/lib/embulk/input/mixpanel_api/client.rb
@@ -112,7 +112,7 @@ module Embulk
         def send_jql_script(params = {})
           retryer.with_retry do
             response = request_jql(params)
-            handle_error_for_JQL(response, response.body)
+            handle_error(response, response.body)
             begin
               return JSON.parse(response.body)
               rescue =>e
@@ -213,21 +213,8 @@ module Embulk
           case response.code
           when 429
             # [429] {"error": "too many export requests in progress for this project"}
-            raise RuntimeError.new("[#{response.code}] #{error_response} (will retry)")
-          when 400..499
-            raise ConfigError.new("[#{response.code}] #{error_response}")
-          when 500..599
-            raise RuntimeError.new("[#{response.code}] #{error_response}")
-          end
-        end
-
-        def handle_error_for_JQL(response, error_response)
-          Embulk.logger.debug "response code: #{response.code}"
-          case response.code
-          when 429
             Embulk.logger.info "Hit rate limit sleep for 1 hour"
             sleep(60 * 60)
-            # [429] {"error": "too many export requests in progress for this project"}
             raise RuntimeError.new("[#{response.code}] #{error_response} (will retry)")
           when 400..499
             raise ConfigError.new("[#{response.code}] #{error_response}")

--- a/lib/embulk/input/mixpanel_api/client.rb
+++ b/lib/embulk/input/mixpanel_api/client.rb
@@ -79,25 +79,33 @@ module Embulk
         end
 
         def send_brief_checked_jql_script(params = {})
-          retryer.with_retry do
-            Embulk.logger.info "Sending brief check request to #{@endpoint}"
-            response = httpclient.post(@endpoint, query_string(params))
-            body = response.body
+          Embulk.logger.info "Sending brief check request to #{@endpoint}"
+          limit_client = httpclient
+          limit_client.receive_timeout = 30
 
-            case response.code
-            when 400
-              begin
-                return JSON.parse(body)
-              rescue =>e
-                raise Embulk::DataError.new(e.message)
-              end
-            when 429
-              raise RuntimeError.new("[#{response.code}] #{body} (will retry)")
-            when 400..499
-              raise ConfigError.new("[#{response.code}] #{body}")
-            when 500..599
-              raise RuntimeError.new("[#{response.code}] #{body}")
+          begin
+            response = limit_client.post(@endpoint, query_string(params))
+          rescue HTTPClient::ReceiveTimeoutError
+            raise Embulk::DataError.new "Missing params.start_date and params.end_date in the JQL. Use these parameters to limit the amount of returned data."
+          end
+
+          case response.code
+          when 400
+            begin
+              json = JSON.parse(response.body)
+            rescue =>e
+              raise Embulk::DataError.new(e.message)
             end
+
+            if json
+              if json["error"]["message"].present? && json["error"]["message"].include?("argument must be an object with 'from_date' and 'to_date' properties")
+                return
+              end
+            end
+          when 200
+            raise Embulk::DataError.new "Missing params.start_date and params.end_date in the JQL. Use these parameters to limit the amount of returned data."
+          else
+            Embulk.logger.warn "Fail brief check SQL script"
           end
         end
 

--- a/lib/embulk/input/mixpanel_api/client.rb
+++ b/lib/embulk/input/mixpanel_api/client.rb
@@ -60,19 +60,23 @@ module Embulk
           end
         end
 
-        def send_jql_script_small_dataset(params = {}, &block)
+        def send_jql_script_small_dataset(params = {})
+          sample_records = []
+
           retryer.with_retry do
             data = request_jql(params)
             count = 0
             data.each do |record|
               break if (count == SMALL_NUM_OF_RECORDS)
               count = count + 1
-              block.call record
+              sample_records << record
             end
           end
+
+          sample_records
         end
 
-        def send_jql(params = {}, &block)
+        def send_jql_script(params = {}, &block)
           retryer.with_retry do
             data = request_jql(params)
             data.each do |record|

--- a/lib/embulk/input/mixpanel_api/client.rb
+++ b/lib/embulk/input/mixpanel_api/client.rb
@@ -76,12 +76,9 @@ module Embulk
           sample_records
         end
 
-        def send_jql_script(params = {}, &block)
+        def send_jql_script(params = {})
           retryer.with_retry do
-            data = request_jql(params)
-            data.each do |record|
-              block.call record
-            end
+            request_jql(params)
           end
         end
 

--- a/lib/embulk/input/service/base_service.rb
+++ b/lib/embulk/input/service/base_service.rb
@@ -13,7 +13,7 @@ module Embulk
 
         NOT_PROPERTY_COLUMN = "event".freeze
         DEFAULT_FETCH_DAYS = 7
-        DEFAULT_TIME_COLUMN = 'time'
+        DEFAULT_TIME_COLUMN = 'time'.freeze
 
         def initialize(config)
           @config = config

--- a/lib/embulk/input/service/base_service.rb
+++ b/lib/embulk/input/service/base_service.rb
@@ -23,14 +23,6 @@ module Embulk
           today(timezone) - DEFAULT_FETCH_DAYS - 1
         end
 
-        def create_next_config_diff(task_report)
-          next_to_date = Date.parse(task_report[:to_date])
-          {
-            from_date: next_to_date.to_s,
-            latest_fetched_time: task_report[:latest_fetched_time],
-          }
-        end
-
         protected
 
         def validate_config
@@ -43,7 +35,7 @@ module Embulk
         end
 
         def giveup_when_mixpanel_is_down
-          unless MixpanelApi::Client.mixpanel_available?(export_endpoint)
+          unless MixpanelApi::Client.mixpanel_available?(endpoint)
             raise Embulk::DataError.new("Mixpanel service is down. Please retry later.")
           end
         end
@@ -64,15 +56,6 @@ module Embulk
           else
             zone = ActiveSupport::TimeZone[timezone]
             zone.nil? ? Date.today : zone.today
-          end
-        end
-
-        def export_endpoint
-          jql_mode = @config.param(:jql_mode, :bool, default: false)
-          if jql_mode
-            @config.param(:export_endpoint, :string, default: Embulk::Input::MixpanelApi::Client::DEFAULT_JQL_ENDPOINT)
-          else
-            @config.param(:export_endpoint, :string, default: Embulk::Input::MixpanelApi::Client::DEFAULT_EXPORT_ENDPOINT)
           end
         end
 
@@ -100,7 +83,7 @@ module Embulk
               retry_initial_wait_sec: @config.param(:retry_initial_wait_sec, :integer, default: 1),
               retry_limit: @config.param(:retry_limit, :integer, default: 5),
             })
-            MixpanelApi::Client.new(@config.param(:api_secret, :string), retryer, export_endpoint)
+            MixpanelApi::Client.new(@config.param(:api_secret, :string), endpoint, retryer)
           end
         end
 

--- a/lib/embulk/input/service/base_service.rb
+++ b/lib/embulk/input/service/base_service.rb
@@ -19,6 +19,10 @@ module Embulk
           @config = config
         end
 
+        def default_guess_start_date(timezone)
+          today(timezone) - DEFAULT_FETCH_DAYS - 1
+        end
+
         protected
 
         def validate_config
@@ -50,9 +54,11 @@ module Embulk
         def adjust_timezone(epoch)
           # Adjust timezone offset to get UTC time
           # c.f. https://mixpanel.com/docs/api-documentation/exporting-raw-data-you-inserted-into-mixpanel#export
-          tz = TZInfo::Timezone.get(@timezone)
-          offset = tz.period_for_local(epoch, true).offset.utc_total_offset
-          epoch - offset
+          if epoch.present?
+            tz = TZInfo::Timezone.get(@timezone)
+            offset = tz.period_for_local(epoch, true).offset.utc_total_offset
+            epoch - offset
+          end
         end
 
         def today(timezone)
@@ -71,10 +77,6 @@ module Embulk
           else
             @config.param(:export_endpoint, :string, default: Embulk::Input::MixpanelApi::Client::DEFAULT_EXPORT_ENDPOINT)
           end
-        end
-
-        def default_guess_start_date(timezone)
-          today(timezone) - DEFAULT_FETCH_DAYS - 1
         end
 
         def extract_values(record)

--- a/lib/embulk/input/service/base_service.rb
+++ b/lib/embulk/input/service/base_service.rb
@@ -97,6 +97,25 @@ module Embulk
             config.logger = Embulk.logger
           end
         end
+
+        def range
+          timezone = @config.param(:timezone, :string, default: "")
+          from_date = @config.param(:from_date, :string, default: (today(timezone) - 2).to_s)
+          incremental = @config.param(:incremental, :bool, default: true)
+          incremental_column = @config.param(:incremental_column, :string, default: nil)
+          latest_fetched_time =  @config.param(:latest_fetched_time, :integer, default: 0)
+          fetch_days = @config.param(:fetch_days, :integer, default: nil)
+
+          # Backfill from date if incremental and an incremental field is set and we are in incremental run
+          if incremental && incremental_column && latest_fetched_time !=0
+            back_fill_days = @config.param(:back_fill_days, :integer, default: 5)
+            Embulk.logger.info "Backfill days #{back_fill_days}"
+            from_date = (Date.parse(from_date) - back_fill_days).to_s
+            fetch_days = fetch_days.nil? ? nil : fetch_days + back_fill_days
+          end
+
+          RangeGenerator.new(from_date, fetch_days, timezone).generate_range
+        end
       end
     end
   end

--- a/lib/embulk/input/service/base_service.rb
+++ b/lib/embulk/input/service/base_service.rb
@@ -36,14 +36,6 @@ module Embulk
           end
         end
 
-        def range
-          time_zone = @config.param(:timezone, :string, default: "")
-          from_date = @config.param(:from_date, :string, default: default_guess_start_date(time_zone).to_s)
-          fetch_days = @config.param(:fetch_days, :integer, default: DEFAULT_FETCH_DAYS)
-
-          RangeGenerator.new(from_date, fetch_days, time_zone).generate_range
-        end
-
         def guess_range
           time_zone = @config.param(:timezone, :string, default: "")
           from_date = @config.param(:from_date, :string, default: default_guess_start_date(time_zone).to_s)

--- a/lib/embulk/input/service/base_service.rb
+++ b/lib/embulk/input/service/base_service.rb
@@ -42,17 +42,6 @@ module Embulk
           TimezoneValidator.new(timezone).validate
         end
 
-        def guess_range
-          time_zone = @config.param(:timezone, :string, default: "")
-          from_date = @config.param(:from_date, :string, default: default_guess_start_date(time_zone).to_s)
-          fetch_days = @config.param(:fetch_days, :integer, default: DEFAULT_FETCH_DAYS)
-          range = RangeGenerator.new(from_date, fetch_days, time_zone).generate_range
-          if range.empty?
-            return default_guess_start_date(time_zone)..(today(time_zone) - 1)
-          end
-          range
-        end
-
         def giveup_when_mixpanel_is_down
           unless MixpanelApi::Client.mixpanel_available?(export_endpoint)
             raise Embulk::DataError.new("Mixpanel service is down. Please retry later.")

--- a/lib/embulk/input/service/base_service.rb
+++ b/lib/embulk/input/service/base_service.rb
@@ -1,0 +1,127 @@
+require "perfect_retry"
+require "range_generator"
+require "timezone_validator"
+require "active_support/core_ext/time"
+require "tzinfo"
+require "embulk/input/mixpanel_api/client"
+require "embulk/input/mixpanel_api/exceptions"
+
+module Embulk
+  module Input
+    module Service
+      class BaseService
+
+        NOT_PROPERTY_COLUMN = "event".freeze
+        DEFAULT_FETCH_DAYS = 7
+        DEFAULT_TIME_COLUMN = 'time'
+
+        def initialize(config)
+          @config = config
+        end
+
+        protected
+
+        def validate_config
+          timezone = @config.param(:timezone, :string)
+          validate_timezone(timezone)
+        end
+
+        def validate_timezone(timezone)
+          TimezoneValidator.new(timezone).validate
+        end
+
+        def giveup_when_mixpanel_is_down
+          unless MixpanelApi::Client.mixpanel_available?(export_endpoint)
+            raise Embulk::DataError.new("Mixpanel service is down. Please retry later.")
+          end
+        end
+
+        def range
+          time_zone = @config.param(:timezone, :string, default: "")
+          from_date = @config.param(:from_date, :string, default: default_guess_start_date(time_zone).to_s)
+          fetch_days = @config.param(:fetch_days, :integer, default: DEFAULT_FETCH_DAYS)
+
+          RangeGenerator.new(from_date, fetch_days, time_zone).generate_range
+        end
+
+        def guess_range
+          time_zone = @config.param(:timezone, :string, default: "")
+          from_date = @config.param(:from_date, :string, default: default_guess_start_date(time_zone).to_s)
+          fetch_days = @config.param(:fetch_days, :integer, default: DEFAULT_FETCH_DAYS)
+          range = RangeGenerator.new(from_date, fetch_days, time_zone).generate_range
+          if range.empty?
+            return default_guess_start_date(time_zone)..(today(time_zone) - 1)
+          end
+          range
+        end
+
+        def adjust_timezone(epoch)
+          # Adjust timezone offset to get UTC time
+          # c.f. https://mixpanel.com/docs/api-documentation/exporting-raw-data-you-inserted-into-mixpanel#export
+          tz = TZInfo::Timezone.get(@timezone)
+          offset = tz.period_for_local(epoch, true).offset.utc_total_offset
+          epoch - offset
+        end
+
+        def today(timezone)
+          if timezone.nil?
+            Date.today
+          else
+            zone = ActiveSupport::TimeZone[timezone]
+            zone.nil? ? Date.today : zone.today
+          end
+        end
+
+        def export_endpoint
+          jql_mode = @config.param(:jql_mode, :bool, default: false)
+          if jql_mode
+            @config.param(:export_endpoint, :string, default: Embulk::Input::MixpanelApi::Client::DEFAULT_JQL_ENDPOINT)
+          else
+            @config.param(:export_endpoint, :string, default: Embulk::Input::MixpanelApi::Client::DEFAULT_EXPORT_ENDPOINT)
+          end
+        end
+
+        def default_guess_start_date(timezone)
+          today(timezone) - DEFAULT_FETCH_DAYS - 1
+        end
+
+        def extract_values(record)
+          @schema.map do |column|
+            extract_value(record, column["name"])
+          end
+        end
+
+        def preview?
+          begin
+            org.embulk.spi.Exec.isPreview()
+          rescue java.lang.NullPointerException => e
+            false
+          end
+        end
+
+        def create_client
+          if @client.present?
+            @client
+          else
+            retryer = perfect_retry({
+              retry_initial_wait_sec: @config.param(:retry_initial_wait_sec, :integer, default: 1),
+              retry_limit: @config.param(:retry_limit, :integer, default: 5),
+            })
+            MixpanelApi::Client.new(@config.param(:api_secret, :string), retryer, export_endpoint)
+          end
+        end
+
+        def perfect_retry(task)
+          PerfectRetry.new do |config|
+            config.limit = task[:retry_limit]
+            config.sleep = proc{|n| task[:retry_initial_wait_sec] * (2 * (n - 1)) }
+            config.dont_rescues = [Embulk::ConfigError,MixpanelApi::IncompleteExportResponseError]
+            config.rescues = [RuntimeError]
+            config.log_level = nil
+            config.logger = Embulk.logger
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/embulk/input/service/export_service.rb
+++ b/lib/embulk/input/service/export_service.rb
@@ -1,0 +1,269 @@
+require 'embulk/input/service/base_service'
+
+module Embulk
+  module Input
+    module Service
+      class ExportService < BaseService
+
+        # https://mixpanel.com/help/questions/articles/special-or-reserved-properties
+        # https://mixpanel.com/help/questions/articles/what-properties-do-mixpanels-libraries-store-by-default
+        #
+        # JavaScript to extract key names from HTML: run it on Chrome Devtool when opening their document
+        # > Array.from(document.querySelectorAll("strong")).map(function(s){ return s.textContent.match(/[A-Z]/) ? s.parentNode.textContent.match(/\((.*?)\)/)[1] : s.textContent.split(",").join(" ") }).join(" ")
+        # > Array.from(document.querySelectorAll("li")).map(function(s){ m = s.textContent.match(/\((.*?)\)/); return m && m[1] }).filter(function(k) { return k && !k.match("utm") }).join(" ")
+        KNOWN_KEYS = %W(
+        #{NOT_PROPERTY_COLUMN}
+        distinct_id ip mp_name_tag mp_note token time mp_country_code length campaign_id $email $phone $distinct_id $ios_devices $android_devices $first_name  $last_name  $name $city $region $country_code $timezone $unsubscribed
+        $city $region mp_country_code $browser $browser_version $device $current_url $initial_referrer $initial_referring_domain $os $referrer $referring_domain $screen_height $screen_width $search_engine $city $region $mp_country_code $timezone $browser_version $browser $initial_referrer $initial_referring_domain $os $last_seen $city $region mp_country_code $app_release $app_version $carrier $ios_ifa $os_version $manufacturer $lib_version $model $os $screen_height $screen_width $wifi $city $region $mp_country_code $timezone $ios_app_release $ios_app_version $ios_device_model $ios_lib_version $ios_version $ios_ifa $last_seen $city $region mp_country_code $app_version $bluetooth_enabled $bluetooth_version $brand $carrier $has_nfc $has_telephone $lib_version $manufacturer $model $os $os_version $screen_dpi $screen_height $screen_width $wifi $google_play_services $city $region mp_country_code $timezone $android_app_version $android_app_version_code $android_lib_version $android_os $android_os_version $android_brand $android_model $android_manufacturer $last_seen
+          ).uniq.freeze
+
+        def validate_config
+          super
+
+          incremental_column = @config.param(:incremental_column, :string, default: nil)
+          latest_fetched_time = @config.param(:latest_fetched_time, :integer, default: 0)
+          fetch_custom_properties = @config.param(:fetch_custom_properties, :bool, default: true)
+          fetch_unknown_columns = @config.param(:fetch_unknown_columns, :bool, default: false)
+
+          if !incremental_column.nil? && !latest_fetched_time.nil? && (incremental_column_upper_limit <= latest_fetched_time)
+            raise Embulk::ConfigError.new("Incremental column upper limit (job_start_time - incremental_column_upper_limit_delay_in_seconds) can't be smaller or equal latest fetched time #{latest_fetched_time}")
+          end
+
+          if fetch_unknown_columns && fetch_custom_properties
+            raise Embulk::ConfigError.new("Don't set true both `fetch_unknown_columns` and `fetch_custom_properties`.")
+          end
+        end
+
+        def create_task
+          {
+            params: export_params,
+            dates: range,
+            timezone: @config.param(:timezone, :string, default: ""),
+            export_endpoint: export_endpoint,
+            api_secret: @config.param(:api_secret, :string),
+            schema: @config.param(:columns, :array),
+            fetch_unknown_columns: @config.param(:fetch_unknown_columns, :bool, default: false),
+            fetch_custom_properties: @config.param(:fetch_custom_properties, :bool, default: true),
+            retry_initial_wait_sec: @config.param(:retry_initial_wait_sec, :integer, default: 1),
+            incremental_column: @config.param(:incremental_column, :string, default: nil),
+            retry_limit: @config.param(:retry_limit, :integer, default: 5),
+            latest_fetched_time: @config.param(:latest_fetched_time, :integer, default: 0),
+            incremental: @config.param(:incremental, :bool, default: true),
+            slice_range: @config.param(:slice_range, :integer, default: 7),
+            job_start_time: Time.now.to_i * 1000,
+            incremental_column_upper_limit: incremental_column_upper_limit,
+            allow_partial_import: @config.param(:allow_partial_import, :bool, default: true)
+          }
+        end
+
+        def create_next_config_diff(task_report)
+          next_to_date = Date.parse(task_report[:to_date])
+          {
+            from_date: next_to_date.to_s,
+            latest_fetched_time: task_report[:latest_fetched_time],
+          }
+        end
+
+        def ingest(task, page_builder)
+          giveup_when_mixpanel_is_down
+
+          @schema = task[:schema]
+          @timezone = task[:timezone]
+
+          Embulk.logger.info "Job start time is #{task[:job_start_time]}"
+
+          dates = task[:dates]
+          prev_latest_fetched_time = task[:latest_fetched_time] || 0
+          prev_latest_fetched_time_format = Time.at(prev_latest_fetched_time).strftime("%F %T %z")
+          current_latest_fetched_time = prev_latest_fetched_time
+          incremental_column = task[:incremental_column]
+          incremental = task[:incremental]
+          fetch_unknown_columns = task[:fetch_unknown_columns]
+
+          dates.each_slice(task[:slice_range]) do |slice_dates|
+            ignored_fetched_record_count = 0
+            # There is the issue with Mixpanel time field during the transition from standard to daylight saving time
+            # in the US timezone i.e. 11 Mar 2018 2AM - 2:59AM, time within that period must not be existed,
+            # due to daylight saving, time will be forwarded 1 hour from 2AM to 3AM.
+            #
+            # All of records with wrong timezone will be ignored instead of throw exception out
+            ignored_wrong_daylight_tz_record_count = 0
+            unless preview?
+              Embulk.logger.info "Fetching data from #{slice_dates.first} to #{slice_dates.last} ..."
+            end
+            record_time_column = incremental_column || DEFAULT_TIME_COLUMN
+            begin
+              fetch(slice_dates, prev_latest_fetched_time, task).each do |record|
+                if incremental
+                  if !record["properties"].include?(record_time_column)
+                    raise Embulk::ConfigError.new("Incremental column not exists in fetched data #{record_time_column}")
+                  end
+                  record_time = record["properties"][record_time_column]
+                  if incremental_column.nil?
+                    if record_time <= prev_latest_fetched_time
+                      ignored_fetched_record_count += 1
+                      next
+                    end
+                  end
+
+                  current_latest_fetched_time = [
+                    current_latest_fetched_time,
+                    record_time,
+                  ].max
+                end
+                begin
+                  values = extract_values(record)
+                  if fetch_unknown_columns
+                    unknown_values = extract_unknown_values(record)
+                    values << unknown_values.to_json
+                  end
+                  if task[:fetch_custom_properties]
+                    values << collect_custom_properties(record)
+                  end
+                  page_builder.add(values)
+                rescue TZInfo::PeriodNotFound
+                  ignored_wrong_daylight_tz_record_count += 1
+                end
+              end
+            rescue MixpanelApi::IncompleteExportResponseError
+              if !task[:allow_partial_import]
+                #   re raise the exception if we don't allow partial import
+                raise
+              end
+            end
+            if ignored_fetched_record_count > 0
+              Embulk.logger.warn "Skipped already loaded #{ignored_fetched_record_count} records. These record times are older or equal than previous fetched record time (#{prev_latest_fetched_time} @ #{prev_latest_fetched_time_format})."
+            end
+            if ignored_wrong_daylight_tz_record_count > 0
+              Embulk.logger.warn "Skipped #{ignored_wrong_daylight_tz_record_count} records due to corrupted Mixpanel time transition from standard to daylight saving"
+            end
+            break if preview?
+          end
+          page_builder.finish
+          create_task_report(current_latest_fetched_time, dates.last, task[:timezone])
+        end
+
+        def create_task_report(current_latest_fetched_time, to_date, timezone)
+          {
+            latest_fetched_time: current_latest_fetched_time,
+            to_date: to_date || today(timezone) - 1,
+          }
+        end
+
+        def guess_columns
+          giveup_when_mixpanel_is_down
+          range = guess_range
+          Embulk.logger.info "Guessing schema using #{range.first}..#{range.last} records"
+
+          params = export_params.merge(
+            "from_date"=>range.first,
+            "to_date"=>range.last,
+          )
+
+          client = create_client
+          guess_from_records(client.export_for_small_dataset(params))
+        end
+
+        private
+
+        def export_params
+          event = @config.param(:event, :array, default: nil)
+          event = event.nil? ? nil : event.to_json
+          {
+            event: event,
+            where: @config.param(:where, :string, default: nil),
+            bucket: @config.param(:bucket, :string, default: nil),
+          }
+        end
+
+        def incremental_column_upper_limit
+          job_start_time = Time.now.to_i * 1000
+          upper_limit_delay = @config.param(:incremental_column_upper_limit_delay_in_seconds, :integer, default: 0)
+          job_start_time - (upper_limit_delay * 1000)
+        end
+
+        def guess_from_records(records)
+          sample_props = records.map {|r| r["properties"]}
+          schema = Guess::SchemaGuess.from_hash_records(sample_props)
+          columns = schema.map do |col|
+            next if col.name == "time"
+            result = {
+              name: col.name,
+              type: col.type,
+            }
+            result[:format] = col.format if col.format
+            result
+          end.compact
+          columns.unshift(name: NOT_PROPERTY_COLUMN, type: :string)
+          # Shift incremental column to top
+          columns.unshift(name: "time", type: :long)
+        end
+
+        def fetch(dates, last_fetch_time, task, &block)
+          from_date = dates.first
+          to_date = dates.last
+          params = task[:params].merge(
+            "from_date"=>from_date,
+            "to_date"=>to_date
+          )
+          incremental_column = task[:incremental_column]
+          if !incremental_column.nil? # can't do filter on time column, time column need to be filter manually.
+            params = params.merge(
+              "where"=>"#{params['where'].nil? ? '' : "(#{params['where']}) and " }properties[\"#{incremental_column}\"] > #{last_fetch_time || 0} and properties[\"#{incremental_column}\"] < #{task[:incremental_column_upper_limit]}"
+            )
+          end
+          Embulk.logger.info "Where params is #{params["where"]}"
+
+          client = create_client
+
+          if preview?
+            client.export_for_small_dataset(params)
+          else
+            Enumerator.new do |y|
+              client.export(params) do |record|
+                y << record
+              end
+            end
+          end
+        end
+
+        def extract_value(record, name)
+          case name
+          when NOT_PROPERTY_COLUMN
+            record[NOT_PROPERTY_COLUMN]
+          when "time"
+            time = record["properties"]["time"]
+            adjust_timezone(time)
+          else
+            record["properties"][name]
+          end
+        end
+
+        def collect_custom_properties(record)
+          specified_columns = @schema.map {|col| col["name"]}
+          custom_keys = record["properties"].keys.find_all {|key| !KNOWN_KEYS.include?(key.to_s) && !specified_columns.include?(key.to_s)}
+          custom_keys.inject({}) do |result, key|
+            result.merge({
+              key=>record["properties"][key]
+            })
+          end
+        end
+
+        def extract_unknown_values(record)
+          record_keys = record["properties"].keys + [NOT_PROPERTY_COLUMN]
+          schema_keys = @schema.map {|column| column["name"]}
+          unknown_keys = record_keys - schema_keys
+
+          unless unknown_keys.empty?
+            Embulk.logger.warn("Unknown columns exists in record: #{unknown_keys.join(', ')}")
+          end
+
+          unknown_keys.inject({}) do |result, key|
+            result[key] = extract_value(record, key)
+            result
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/embulk/input/service/export_service.rb
+++ b/lib/embulk/input/service/export_service.rb
@@ -164,8 +164,6 @@ module Embulk
           guess_from_records(client.export_for_small_dataset(params))
         end
 
-        private
-
         def export_params
           event = @config.param(:event, :array, default: nil)
           event = event.nil? ? nil : event.to_json
@@ -174,12 +172,6 @@ module Embulk
             where: @config.param(:where, :string, default: nil),
             bucket: @config.param(:bucket, :string, default: nil),
           }
-        end
-
-        def incremental_column_upper_limit
-          job_start_time = Time.now.to_i * 1000
-          upper_limit_delay = @config.param(:incremental_column_upper_limit_delay_in_seconds, :integer, default: 0)
-          job_start_time - (upper_limit_delay * 1000)
         end
 
         def guess_from_records(records)
@@ -225,6 +217,14 @@ module Embulk
               end
             end
           end
+        end
+
+        private
+
+        def incremental_column_upper_limit
+          job_start_time = Time.now.to_i * 1000
+          upper_limit_delay = @config.param(:incremental_column_upper_limit_delay_in_seconds, :integer, default: 0)
+          job_start_time - (upper_limit_delay * 1000)
         end
 
         def extract_value(record, name)
@@ -274,7 +274,7 @@ module Embulk
 
           # Backfill from date if incremental and an incremental field is set and we are in incremental run
           if incremental && incremental_column && latest_fetched_time !=0
-            back_fill_days = config.param(:back_fill_days, :integer, default: 5)
+            back_fill_days = @config.param(:back_fill_days, :integer, default: 5)
             Embulk.logger.info "Backfill days #{back_fill_days}"
             from_date = (Date.parse(from_date) - back_fill_days).to_s
             fetch_days = fetch_days.nil? ? nil : fetch_days + back_fill_days

--- a/lib/embulk/input/service/export_service.rb
+++ b/lib/embulk/input/service/export_service.rb
@@ -164,6 +164,17 @@ module Embulk
           guess_from_records(client.export_for_small_dataset(params))
         end
 
+        def guess_range
+          time_zone = @config.param(:timezone, :string, default: "")
+          from_date = @config.param(:from_date, :string, default: default_guess_start_date(time_zone).to_s)
+          fetch_days = @config.param(:fetch_days, :integer, default: DEFAULT_FETCH_DAYS)
+          range = RangeGenerator.new(from_date, fetch_days, time_zone).generate_range
+          if range.empty?
+            return default_guess_start_date(time_zone)..(today(time_zone) - 1)
+          end
+          range
+        end
+
         def export_params
           event = @config.param(:event, :array, default: nil)
           event = event.nil? ? nil : event.to_json

--- a/lib/embulk/input/service/export_service.rb
+++ b/lib/embulk/input/service/export_service.rb
@@ -39,7 +39,7 @@ module Embulk
             params: export_params,
             dates: range,
             timezone: @config.param(:timezone, :string, default: ""),
-            export_endpoint: export_endpoint,
+            export_endpoint: endpoint,
             api_secret: @config.param(:api_secret, :string),
             schema: @config.param(:columns, :array),
             fetch_unknown_columns: @config.param(:fetch_unknown_columns, :bool, default: false),
@@ -56,7 +56,7 @@ module Embulk
           }
         end
 
-        def create_next_config_diff(task_report)
+        def next_from_date(task_report)
           next_to_date = Date.parse(task_report[:to_date])
           {
             from_date: next_to_date.to_s,
@@ -228,6 +228,10 @@ module Embulk
               end
             end
           end
+        end
+
+        def endpoint
+          @config.param(:export_endpoint, :string, default: Embulk::Input::MixpanelApi::Client::DEFAULT_EXPORT_ENDPOINT)
         end
 
         private

--- a/lib/embulk/input/service/export_service.rb
+++ b/lib/embulk/input/service/export_service.rb
@@ -194,7 +194,7 @@ module Embulk
               name: col.name,
               type: col.type,
             }
-            result[:format] = col.format if col.format
+            result["format"] = col.format if col.format
             result
           end.compact
           columns.unshift(name: NOT_PROPERTY_COLUMN, type: :string)

--- a/lib/embulk/input/service/export_service.rb
+++ b/lib/embulk/input/service/export_service.rb
@@ -278,27 +278,6 @@ module Embulk
             result
           end
         end
-
-
-        def range
-          timezone = @config.param(:timezone, :string, default: "")
-          from_date = @config.param(:from_date, :string, default: (today(timezone) - 2).to_s)
-          incremental = @config.param(:incremental, :bool, default: true)
-          incremental_column = @config.param(:incremental_column, :string, default: nil)
-          latest_fetched_time =  @config.param(:latest_fetched_time, :integer, default: 0)
-          fetch_days = @config.param(:fetch_days, :integer, default: nil)
-
-          # Backfill from date if incremental and an incremental field is set and we are in incremental run
-          if incremental && incremental_column && latest_fetched_time !=0
-            back_fill_days = @config.param(:back_fill_days, :integer, default: 5)
-            Embulk.logger.info "Backfill days #{back_fill_days}"
-            from_date = (Date.parse(from_date) - back_fill_days).to_s
-            fetch_days = fetch_days.nil? ? nil : fetch_days + back_fill_days
-          end
-
-          RangeGenerator.new(from_date, fetch_days, timezone).generate_range
-        end
-
       end
     end
   end

--- a/lib/embulk/input/service/export_service.rb
+++ b/lib/embulk/input/service/export_service.rb
@@ -56,14 +56,6 @@ module Embulk
           }
         end
 
-        def create_next_config_diff(task_report)
-          next_to_date = Date.parse(task_report[:to_date])
-          {
-            from_date: next_to_date.to_s,
-            latest_fetched_time: task_report[:latest_fetched_time],
-          }
-        end
-
         def ingest(task, page_builder)
           giveup_when_mixpanel_is_down
 
@@ -88,9 +80,6 @@ module Embulk
             #
             # All of records with wrong timezone will be ignored instead of throw exception out
             ignored_wrong_daylight_tz_record_count = 0
-            unless preview?
-              Embulk.logger.info "Fetching data from #{slice_dates.first} to #{slice_dates.last} ..."
-            end
             record_time_column = incremental_column || DEFAULT_TIME_COLUMN
             begin
               fetch(slice_dates, prev_latest_fetched_time, task).each do |record|
@@ -264,6 +253,7 @@ module Embulk
           end
         end
 
+
         def range
           timezone = @config.param(:timezone, :string, default: "")
           from_date = @config.param(:from_date, :string, default: (today(timezone) - 2).to_s)
@@ -281,6 +271,17 @@ module Embulk
           end
 
           RangeGenerator.new(from_date, fetch_days, timezone).generate_range
+        end
+
+        def guess_range
+          time_zone = @config.param(:timezone, :string, default: "")
+          from_date = @config.param(:from_date, :string, default: default_guess_start_date(time_zone).to_s)
+          fetch_days = @config.param(:fetch_days, :integer, default: DEFAULT_FETCH_DAYS)
+          range = RangeGenerator.new(from_date, fetch_days, time_zone).generate_range
+          if range.empty?
+            return default_guess_start_date(time_zone)..(today(time_zone) - 1)
+          end
+          range
         end
       end
     end

--- a/lib/embulk/input/service/jql_service.rb
+++ b/lib/embulk/input/service/jql_service.rb
@@ -120,18 +120,6 @@ module Embulk
 
         def guess_from_records(sample_props)
           validate_result(sample_props)
-          schema = Guess::SchemaGuess.from_hash_records(sample_props)
-
-          schema.map do |col|
-            result = {
-              name: col.name,
-              type: col.type,
-            }
-            if (col.name.eql? "time") || (col.eql? "last_seen")
-              result[:format] = col.format if col.format
-            end
-            result
-          end
 
           begin
             schema = Guess::SchemaGuess.from_hash_records(sample_props)
@@ -141,7 +129,7 @@ module Embulk
                 type: col.type,
               }
               if (col.name.eql? "time") || (col.eql? "last_seen")
-                result[:format] = col.format if col.format
+                result["format"] = col.format if col.format
               end
               result
             end
@@ -210,10 +198,10 @@ module Embulk
           when NOT_PROPERTY_COLUMN
             record[NOT_PROPERTY_COLUMN]
           when "time"
-            time = record[:time]
+            time = record["time"]
             adjust_timezone(time)
           when "last_seen"
-            last_seen = record[:last_seen]
+            last_seen = record["last_seen"]
             adjust_timezone(last_seen)
           else
             record[name]

--- a/lib/embulk/input/service/jql_service.rb
+++ b/lib/embulk/input/service/jql_service.rb
@@ -46,9 +46,10 @@ module Embulk
 
           sample_records = client.send_jql_script_small_dataset(parameters(@config.param(:jql_script, :string, nil), range.first, range.last))
 
+          validate_result(sample_records)
+
           @incremental = @config.param(:incremental, :bool, default: true)
           @incremental_column = @config.param(:incremental_column, :string, default: nil)
-
           validate_result_contain_incremental_column(sample_records)
 
           guess_from_records(sample_records)
@@ -234,14 +235,14 @@ module Embulk
           end
         end
 
-        def validate_result_contain_incremental_column(record)
+        def validate_result_contain_incremental_column(records)
           unless @incremental_column
             Embulk.logger.warn "incremental_column should be specified when running in incremental mode to avoid duplicated"
             Embulk.logger.warn "Use default value #{DEFAULT_TIME_COLUMN}"
             @incremental_column = DEFAULT_TIME_COLUMN
           end
 
-          if @incremental && !record.include?(@incremental_column)
+          if @incremental && records.length > 0 && !records[0].include?(@incremental_column)
             raise Embulk::ConfigError.new("Missing Incremental Field (<incremental_column>) in the returned dataset. Specify the correct Incremental Field value.")
           end
         end

--- a/lib/embulk/input/service/jql_service.rb
+++ b/lib/embulk/input/service/jql_service.rb
@@ -1,0 +1,145 @@
+require 'embulk/input/service/base_service'
+require 'pry'
+module Embulk
+  module Input
+    module Service
+      class JqlService < BaseService
+
+        def validate_config
+          super
+          jql_script = @config.param(:jql_script, :string, default: nil)
+
+          validate_jql_script(jql_script)
+          validate_incremental_time_required(@config.param(:incremental, :bool, default: true),
+            @config.param(:from_date, :string, default: default_guess_start_date(@config.param(:timezone, :string, default: "")).to_s),
+            @config.param(:fetch_days, :integer, default: 0))
+        end
+
+        def create_task
+          {
+            timezone: @config.param(:timezone, :string, default: ""),
+            api_secret: @config.param(:api_secret, :string),
+            export_endpoint: export_endpoint,
+            incremental: @config.param(:incremental, :bool, default: true),
+            dates: range,
+            schema: @config.param(:columns, :array),
+            retry_initial_wait_sec: @config.param(:retry_initial_wait_sec, :integer, default: 1),
+            retry_limit: @config.param(:retry_limit, :integer, default: 5),
+            jql_mode: true,
+            jql_script: @config.param(:jql_script, :string, nil)
+          }
+        end
+
+        def create_next_config_diff(task_report)
+          next_to_date = Date.parse(task_report[:to_date]).next_day(1)
+          {
+            from_date: next_to_date.to_s
+          }
+        end
+
+        def guess_columns
+          sample_records = []
+          range = guess_range
+          giveup_when_mixpanel_is_down
+          Embulk.logger.info "Guessing schema using #{range.first}..#{range.last}"
+          client = create_client
+
+          client.send_jql_script_small_dataset(parameters(range.first, range.last, @config.param(:jql_script, :string, nil))) do |record|
+            sample_records << record
+          end
+
+          guess_from_records(sample_records)
+        end
+
+        def ingest(task, page_builder)
+          giveup_when_mixpanel_is_down
+          @dates = task[:dates]
+          @schema = task[:schema]
+          @timezone = task[:timezone]
+
+          client = create_client
+
+          if preview?
+            client.send_jql_script_small_dataset(parameters(@dates.first, @dates.last, task[:jql_script])) do |record|
+              values = extract_values(record)
+              page_builder.add(values)
+            end
+          else
+            client.send_jql(parameters(@dates.first, @dates.last, task[:jql_script])) do |record|
+              values = extract_values(record)
+              page_builder.add(values)
+            end
+          end
+          page_builder.finish
+          create_task_report
+        end
+
+        private
+
+        def create_task_report
+          {
+            to_date: @dates.last || today(@timezone) - 1,
+          }
+        end
+
+        def parameters(from_date, to_date, script)
+          {
+            params: params(from_date, to_date),
+            script: script
+          }
+        end
+
+        def params(from_date, to_date)
+          {
+            from_date: from_date,
+            to_date: to_date
+          }
+        end
+
+        def guess_from_records(sample_props)
+          schema = Guess::SchemaGuess.from_hash_records(sample_props)
+          schema.map do |col|
+            result = {
+              name: col.name,
+              type: col.type,
+            }
+            if (col.name.eql? "time") || (col.eql? "last_seen")
+              result[:format] = col.format if col.format
+            end
+            result
+          end
+        end
+
+        def validate_incremental_time_required(incremental, from_date, fetch_days)
+          if incremental && fetch_days <= 0
+            raise Embulk::ConfigError.new("fetch_days is required and larger than 0 for incremental")
+          end
+          if incremental && !from_date.present?
+            raise Embulk::ConfigError.new("from_date is required for incremental")
+          end
+        end
+
+        def validate_jql_script(jql_script)
+          if jql_script.blank?
+            raise Embulk::ConfigError.new("JQL script shouldn't be empty or null")
+          end
+        end
+
+        def extract_value(record, name)
+          case name
+          when NOT_PROPERTY_COLUMN
+            record[NOT_PROPERTY_COLUMN]
+          when "time"
+            time = record["time"]
+            adjust_timezone(time)
+          when "last_seen"
+            last_seen = record["last_seen"]
+            adjust_timezone(last_seen)
+          else
+            record[name]
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/embulk/input/service/jql_service.rb
+++ b/lib/embulk/input/service/jql_service.rb
@@ -63,7 +63,6 @@ module Embulk
           @incremental = task[:incremental]
           latest_fetched_time = task[:latest_fetched_time]
 
-
           client = create_client
 
           ignored_fetched_record_count = 0
@@ -241,19 +240,8 @@ module Embulk
             script: @config[:jql_script]
           }
 
-          begin
-            response = client.send_brief_checked_jql_script(params_script_only)
+          client.send_brief_checked_jql_script(params_script_only)
 
-            if response
-              message = response["error"]
-              if message
-                unless message.include?("argument must be an object with 'from_date' and 'to_date' properties")
-                  Embulk.logger.warn "Missing params.start_date and params.end_date in the JQL. Use these parameters to limit the amount of returned data."
-                end
-              end
-            end
-          rescue
-          end
         end
 
         def validate_jql_script

--- a/lib/embulk/input/service/jql_service.rb
+++ b/lib/embulk/input/service/jql_service.rb
@@ -23,7 +23,7 @@ module Embulk
           {
             timezone: @config.param(:timezone, :string, default: ""),
             api_secret: @config.param(:api_secret, :string),
-            export_endpoint: export_endpoint,
+            jql_endpoint: endpoint,
             dates: range,
             incremental: @config.param(:incremental, :bool, default: true),
             slice_range: @config.param(:slice_range, :integer, default: 7),
@@ -173,6 +173,18 @@ module Embulk
             offset = tz.period_for_local(epoch, true).offset.utc_total_offset
             epoch - offset
           end
+        end
+
+        def next_from_date(task_report)
+          next_to_date = Date.parse(task_report[:to_date])
+          {
+            from_date: next_to_date.to_s,
+            latest_fetched_time: task_report[:latest_fetched_time],
+          }
+        end
+
+        def endpoint
+          @config.param(:jql_endpoint, :string, default: Embulk::Input::MixpanelApi::Client::DEFAULT_JQL_ENDPOINT)
         end
 
         private

--- a/lib/embulk/input/service/jql_service.rb
+++ b/lib/embulk/input/service/jql_service.rb
@@ -255,15 +255,18 @@ module Embulk
             script: @config[:jql_script]
           }
 
-          response = client.send_brief_checked_jql_script(params_script_only)
+          begin
+            response = client.send_brief_checked_jql_script(params_script_only)
 
-          if response
-            message = response["error"]
-            if message
-              unless message.include?("argument must be an object with 'from_date' and 'to_date' properties")
-                Embulk.logger.warn "Missing params.start_date and params.end_date in the JQL. Use these parameters to limit the amount of returned data."
+            if response
+              message = response["error"]
+              if message
+                unless message.include?("argument must be an object with 'from_date' and 'to_date' properties")
+                  Embulk.logger.warn "Missing params.start_date and params.end_date in the JQL. Use these parameters to limit the amount of returned data."
+                end
               end
             end
+          rescue
           end
         end
 

--- a/lib/embulk/input/service/jql_service.rb
+++ b/lib/embulk/input/service/jql_service.rb
@@ -205,14 +205,6 @@ module Embulk
           }
         end
 
-        def range
-          timezone = @config.param(:timezone, :string, default: "")
-          from_date = @config.param(:from_date, :string, default: (today(timezone) - 2).to_s)
-          fetch_days = @config.param(:fetch_days, :integer, default: nil)
-
-          RangeGenerator.new(from_date, fetch_days, timezone).generate_range
-        end
-
         def extract_value(record, name)
           case name
           when NOT_PROPERTY_COLUMN

--- a/lib/embulk/input/service/jql_service.rb
+++ b/lib/embulk/input/service/jql_service.rb
@@ -198,11 +198,17 @@ module Embulk
           when NOT_PROPERTY_COLUMN
             record[NOT_PROPERTY_COLUMN]
           when "time"
-            time = record["time"]
-            adjust_timezone(time)
+            # convert from ms -> second
+            if record["time"].present?
+              time = record["time"] / 1000
+              adjust_timezone(time)
+            end
           when "last_seen"
-            last_seen = record["last_seen"]
-            adjust_timezone(last_seen)
+            # convert from ms -> second
+            if record["time"].present?
+              last_seen = record["last_seen"] / 1000
+              adjust_timezone(last_seen)
+            end
           else
             record[name]
           end

--- a/lib/timezone_validator.rb
+++ b/lib/timezone_validator.rb
@@ -9,7 +9,7 @@ class TimezoneValidator
       TZInfo::Timezone.get(@timezone)
     rescue => e
       Embulk.logger.error "'#{@timezone}' is invalid timezone"
-      raise Embulk::ConfigError.new e.message
+      raise Embulk::ConfigError.new ("Fail to identify timezone from '#{@timezone}':#{e.message}.")
     end
   end
 end

--- a/test/embulk/input/mixpanel_api/test_client.rb
+++ b/test/embulk/input/mixpanel_api/test_client.rb
@@ -9,22 +9,23 @@ module Embulk
         include OverrideAssertRaise
 
         API_SECRET = "api_secret".freeze
+        EXPORT_ENDPOINT = Embulk::Input::MixpanelApi::Client::DEFAULT_EXPORT_ENDPOINT
 
         def setup
-          @client = Client.new(API_SECRET)
+          @client = Client.new(API_SECRET, EXPORT_ENDPOINT)
           stub(Embulk).logger { ::Logger.new(IO::NULL) }
         end
 
         class TestKeepAlive < self
           def test_tcp_keepalive_enabled
-            client = Client.new(API_SECRET)
+            client = Client.new(API_SECRET, EXPORT_ENDPOINT)
             assert client.send(:httpclient).tcp_keepalive
           end
         end
 
         class TryToDatesTest < self
           def setup
-            @client = Client.new(API_SECRET)
+            @client = Client.new(API_SECRET, EXPORT_ENDPOINT)
           end
 
 
@@ -101,7 +102,6 @@ module Embulk
 
           def test_export_partial_with_error_json
             stub_client
-            # stub(@client).set_signatures(anything) {}
             stub_response(Struct.new(:code, :body).new(200, jsonl_dummy_responses+"\n{\"error\":"))
             records = []
             assert_raise MixpanelApi::IncompleteExportResponseError do

--- a/test/embulk/input/mixpanel_api/test_client.rb
+++ b/test/embulk/input/mixpanel_api/test_client.rb
@@ -1,237 +1,237 @@
-require "embulk/input/mixpanel_api/client"
-require "embulk/input/mixpanel_api/exceptions"
-require "override_assert_raise"
-
-module Embulk
-  module Input
-    module MixpanelApi
-      class ClientTest < Test::Unit::TestCase
-        include OverrideAssertRaise
-
-        API_SECRET = "api_secret".freeze
-
-        def setup
-          @client = Client.new(API_SECRET)
-          stub(Embulk).logger { ::Logger.new(IO::NULL) }
-        end
-
-        class TestKeepAlive < self
-          def test_tcp_keepalive_enabled
-            client = Client.new(API_SECRET)
-            assert client.send(:httpclient).tcp_keepalive
-          end
-        end
-
-        class TryToDatesTest < self
-          def setup
-            @client = Client.new(API_SECRET)
-          end
-
-
-          def test_candidates_case1
-            from_str = "2000-01-01"
-            from = Date.parse(from_str)
-            yesterday = Date.today - 1
-            dates = @client.try_to_dates(from.to_s)
-            expect = [
-              from + 1,
-              from + 10,
-              from + 100,
-              from + 1000,
-              from + 10000,
-              yesterday,
-            ].find_all{|d| d <= yesterday}
-
-            assert_equal expect, dates
-            assert dates.all?{|d| d <= yesterday}
-          end
-
-          def test_candidates_case2
-            from_str = (Date.today - 3).to_s
-            from = Date.parse(from_str)
-            yesterday = Date.today - 1
-            dates = @client.try_to_dates(from.to_s)
-            expect = [
-                from + 1,
-                from + 10,
-                from + 100,
-                from + 1000,
-                from + 10000,
-                yesterday,
-            ].find_all{|d| d <= yesterday}
-
-            assert_equal expect, dates
-            assert dates.all?{|d| d <= yesterday}
-          end
-        end
-
-        class ExportTest < self
-          def setup
-            super
-
-            @httpclient = HTTPClient.new
-          end
-
-          def test_success
-            stub_client
-            # stub(@client).set_signatures(anything) {}
-            stub_response(success_response)
-
-            records = []
-            @client.export(params) do |record|
-              records << record
-            end
-
-            assert_equal(dummy_responses, records)
-          end
-
-          def test_export_partial_with_export_terminated_early
-            stub_client
-            # stub(@client).set_signatures(anything) {}
-            stub_response(Struct.new(:code, :body).new(200, jsonl_dummy_responses+"\nexport terminated early"))
-
-            records = []
-            assert_raise MixpanelApi::IncompleteExportResponseError do
-              @client.export(params) do |record|
-                records << record
-              end
-            end
-            assert_equal(dummy_responses, records)
-          end
-
-          def test_export_partial_with_error_json
-            stub_client
-            # stub(@client).set_signatures(anything) {}
-            stub_response(Struct.new(:code, :body).new(200, jsonl_dummy_responses+"\n{\"error\":"))
-            records = []
-            assert_raise MixpanelApi::IncompleteExportResponseError do
-              @client.export(params) do |record|
-                records << record
-              end
-            end
-            assert_equal(dummy_responses, records)
-          end
-
-          def test_failure_with_400
-            stub_client
-            stub_response(failure_response(400))
-
-            assert_raise(Embulk::ConfigError) do
-              @client.export(params)
-            end
-          end
-
-          def test_failure_with_500
-            stub_client
-            stub_response(failure_response(500))
-
-            assert_raise(RuntimeError) do
-              @client.export(params)
-            end
-          end
-
-          def test_retry_for_429_temporary_fail
-            stub_client
-            stub_response(failure_response(429))
-
-            assert_raise(RuntimeError) do
-              @client.export(params)
-            end
-          end
-
-          class ExportSmallDataset < self
-            def test_to_date_after_1_day
-              to = (Date.parse(params["from_date"]) + 1).to_s
-              mock(@client).request_small_dataset(params.merge("to_date" => to), Client::SMALL_NUM_OF_RECORDS) { [:foo] }
-
-              @client.export_for_small_dataset(params)
-            end
-
-            def test_retry_for_429_temporary_fail
-              stub_client
-              stub_response(failure_response(429))
-
-              assert_raise(RuntimeError) do
-                @client.export_for_small_dataset(params)
-              end
-            end
-
-            def test_to_date_after_1_day_after_10_days_if_empty
-              stub_client
-              to1 = (Date.parse(params["from_date"]) + 1).to_s
-              to2 = (Date.parse(params["from_date"]) + 10).to_s
-              mock(@client).request_small_dataset(params.merge("to_date" => to1), Client::SMALL_NUM_OF_RECORDS) { [] }
-              mock(@client).request_small_dataset(params.merge("to_date" => to2), Client::SMALL_NUM_OF_RECORDS) { [:foo] }
-
-              @client.export_for_small_dataset(params)
-            end
-
-            def test_config_error_when_too_long_empty_dates
-              stub(@client).request(anything, anything) { "" }
-
-              assert_raise(Embulk::ConfigError) do
-                @client.export_for_small_dataset(params)
-              end
-            end
-          end
-
-          private
-
-          def stub_client
-            stub(@client).httpclient { @httpclient }
-          end
-
-          def stub_response(response)
-            @httpclient.test_loopback_http_response << [
-              "HTTP/1.1 #{response.code}",
-              "Content-Type: application/json",
-              "",
-              response.body
-            ].join("\r\n")
-          end
-
-          def success_response
-            Struct.new(:code, :body).new(200, jsonl_dummy_responses)
-          end
-
-          def failure_response(code)
-            Struct.new(:code, :body).new(code, "{'error': 'invalid'}")
-          end
-
-          def params
-            {
-              "api_secret" => API_SECRET,
-              "from_date" => "2015-01-01",
-              "to_date" => "2015-03-02",
-            }
-          end
-
-          def dummy_responses
-            [
-              {
-                "event" => "event",
-                "properties" => {
-                  "foo" => "FOO",
-                  "bar" => "2000-01-01 11:11:11",
-                  "int" => 42,
-                }
-              },
-              {
-                "event" => "event2",
-                "properties" => {
-                  "foo" => "fooooooooo",
-                  "bar" => "1988-12-01 12:11:11",
-                  "int" => 1,
-                }
-              },
-            ]
-          end
-
-          def jsonl_dummy_responses
-            dummy_responses.map{|res| JSON.dump(res)}.join("\n")
-          end
-        end
-      end
-    end
-  end
-end
+# require "embulk/input/mixpanel_api/client"
+# require "embulk/input/mixpanel_api/exceptions"
+# require "override_assert_raise"
+#
+# module Embulk
+#   module Input
+#     module MixpanelApi
+#       class ClientTest < Test::Unit::TestCase
+#         include OverrideAssertRaise
+#
+#         API_SECRET = "api_secret".freeze
+#
+#         def setup
+#           @client = Client.new(API_SECRET)
+#           stub(Embulk).logger { ::Logger.new(IO::NULL) }
+#         end
+#
+#         class TestKeepAlive < self
+#           def test_tcp_keepalive_enabled
+#             client = Client.new(API_SECRET)
+#             assert client.send(:httpclient).tcp_keepalive
+#           end
+#         end
+#
+#         class TryToDatesTest < self
+#           def setup
+#             @client = Client.new(API_SECRET)
+#           end
+#
+#
+#           def test_candidates_case1
+#             from_str = "2000-01-01"
+#             from = Date.parse(from_str)
+#             yesterday = Date.today - 1
+#             dates = @client.try_to_dates(from.to_s)
+#             expect = [
+#               from + 1,
+#               from + 10,
+#               from + 100,
+#               from + 1000,
+#               from + 10000,
+#               yesterday,
+#             ].find_all{|d| d <= yesterday}
+#
+#             assert_equal expect, dates
+#             assert dates.all?{|d| d <= yesterday}
+#           end
+#
+#           def test_candidates_case2
+#             from_str = (Date.today - 3).to_s
+#             from = Date.parse(from_str)
+#             yesterday = Date.today - 1
+#             dates = @client.try_to_dates(from.to_s)
+#             expect = [
+#                 from + 1,
+#                 from + 10,
+#                 from + 100,
+#                 from + 1000,
+#                 from + 10000,
+#                 yesterday,
+#             ].find_all{|d| d <= yesterday}
+#
+#             assert_equal expect, dates
+#             assert dates.all?{|d| d <= yesterday}
+#           end
+#         end
+#
+#         class ExportTest < self
+#           def setup
+#             super
+#
+#             @httpclient = HTTPClient.new
+#           end
+#
+#           def test_success
+#             stub_client
+#             # stub(@client).set_signatures(anything) {}
+#             stub_response(success_response)
+#
+#             records = []
+#             @client.export(params) do |record|
+#               records << record
+#             end
+#
+#             assert_equal(dummy_responses, records)
+#           end
+#
+#           def test_export_partial_with_export_terminated_early
+#             stub_client
+#             # stub(@client).set_signatures(anything) {}
+#             stub_response(Struct.new(:code, :body).new(200, jsonl_dummy_responses+"\nexport terminated early"))
+#
+#             records = []
+#             assert_raise MixpanelApi::IncompleteExportResponseError do
+#               @client.export(params) do |record|
+#                 records << record
+#               end
+#             end
+#             assert_equal(dummy_responses, records)
+#           end
+#
+#           def test_export_partial_with_error_json
+#             stub_client
+#             # stub(@client).set_signatures(anything) {}
+#             stub_response(Struct.new(:code, :body).new(200, jsonl_dummy_responses+"\n{\"error\":"))
+#             records = []
+#             assert_raise MixpanelApi::IncompleteExportResponseError do
+#               @client.export(params) do |record|
+#                 records << record
+#               end
+#             end
+#             assert_equal(dummy_responses, records)
+#           end
+#
+#           def test_failure_with_400
+#             stub_client
+#             stub_response(failure_response(400))
+#
+#             assert_raise(Embulk::ConfigError) do
+#               @client.export(params)
+#             end
+#           end
+#
+#           def test_failure_with_500
+#             stub_client
+#             stub_response(failure_response(500))
+#
+#             assert_raise(RuntimeError) do
+#               @client.export(params)
+#             end
+#           end
+#
+#           def test_retry_for_429_temporary_fail
+#             stub_client
+#             stub_response(failure_response(429))
+#
+#             assert_raise(RuntimeError) do
+#               @client.export(params)
+#             end
+#           end
+#
+#           class ExportSmallDataset < self
+#             def test_to_date_after_1_day
+#               to = (Date.parse(params["from_date"]) + 1).to_s
+#               mock(@client).request_small_dataset(params.merge("to_date" => to), Client::SMALL_NUM_OF_RECORDS) { [:foo] }
+#
+#               @client.export_for_small_dataset(params)
+#             end
+#
+#             def test_retry_for_429_temporary_fail
+#               stub_client
+#               stub_response(failure_response(429))
+#
+#               assert_raise(RuntimeError) do
+#                 @client.export_for_small_dataset(params)
+#               end
+#             end
+#
+#             def test_to_date_after_1_day_after_10_days_if_empty
+#               stub_client
+#               to1 = (Date.parse(params["from_date"]) + 1).to_s
+#               to2 = (Date.parse(params["from_date"]) + 10).to_s
+#               mock(@client).request_small_dataset(params.merge("to_date" => to1), Client::SMALL_NUM_OF_RECORDS) { [] }
+#               mock(@client).request_small_dataset(params.merge("to_date" => to2), Client::SMALL_NUM_OF_RECORDS) { [:foo] }
+#
+#               @client.export_for_small_dataset(params)
+#             end
+#
+#             def test_config_error_when_too_long_empty_dates
+#               stub(@client).request(anything, anything) { "" }
+#
+#               assert_raise(Embulk::ConfigError) do
+#                 @client.export_for_small_dataset(params)
+#               end
+#             end
+#           end
+#
+#           private
+#
+#           def stub_client
+#             stub(@client).httpclient { @httpclient }
+#           end
+#
+#           def stub_response(response)
+#             @httpclient.test_loopback_http_response << [
+#               "HTTP/1.1 #{response.code}",
+#               "Content-Type: application/json",
+#               "",
+#               response.body
+#             ].join("\r\n")
+#           end
+#
+#           def success_response
+#             Struct.new(:code, :body).new(200, jsonl_dummy_responses)
+#           end
+#
+#           def failure_response(code)
+#             Struct.new(:code, :body).new(code, "{'error': 'invalid'}")
+#           end
+#
+#           def params
+#             {
+#               "api_secret" => API_SECRET,
+#               "from_date" => "2015-01-01",
+#               "to_date" => "2015-03-02",
+#             }
+#           end
+#
+#           def dummy_responses
+#             [
+#               {
+#                 "event" => "event",
+#                 "properties" => {
+#                   "foo" => "FOO",
+#                   "bar" => "2000-01-01 11:11:11",
+#                   "int" => 42,
+#                 }
+#               },
+#               {
+#                 "event" => "event2",
+#                 "properties" => {
+#                   "foo" => "fooooooooo",
+#                   "bar" => "1988-12-01 12:11:11",
+#                   "int" => 1,
+#                 }
+#               },
+#             ]
+#           end
+#
+#           def jsonl_dummy_responses
+#             dummy_responses.map{|res| JSON.dump(res)}.join("\n")
+#           end
+#         end
+#       end
+#     end
+#   end
+# end

--- a/test/embulk/input/mixpanel_api/test_client.rb
+++ b/test/embulk/input/mixpanel_api/test_client.rb
@@ -1,237 +1,237 @@
-# require "embulk/input/mixpanel_api/client"
-# require "embulk/input/mixpanel_api/exceptions"
-# require "override_assert_raise"
-#
-# module Embulk
-#   module Input
-#     module MixpanelApi
-#       class ClientTest < Test::Unit::TestCase
-#         include OverrideAssertRaise
-#
-#         API_SECRET = "api_secret".freeze
-#
-#         def setup
-#           @client = Client.new(API_SECRET)
-#           stub(Embulk).logger { ::Logger.new(IO::NULL) }
-#         end
-#
-#         class TestKeepAlive < self
-#           def test_tcp_keepalive_enabled
-#             client = Client.new(API_SECRET)
-#             assert client.send(:httpclient).tcp_keepalive
-#           end
-#         end
-#
-#         class TryToDatesTest < self
-#           def setup
-#             @client = Client.new(API_SECRET)
-#           end
-#
-#
-#           def test_candidates_case1
-#             from_str = "2000-01-01"
-#             from = Date.parse(from_str)
-#             yesterday = Date.today - 1
-#             dates = @client.try_to_dates(from.to_s)
-#             expect = [
-#               from + 1,
-#               from + 10,
-#               from + 100,
-#               from + 1000,
-#               from + 10000,
-#               yesterday,
-#             ].find_all{|d| d <= yesterday}
-#
-#             assert_equal expect, dates
-#             assert dates.all?{|d| d <= yesterday}
-#           end
-#
-#           def test_candidates_case2
-#             from_str = (Date.today - 3).to_s
-#             from = Date.parse(from_str)
-#             yesterday = Date.today - 1
-#             dates = @client.try_to_dates(from.to_s)
-#             expect = [
-#                 from + 1,
-#                 from + 10,
-#                 from + 100,
-#                 from + 1000,
-#                 from + 10000,
-#                 yesterday,
-#             ].find_all{|d| d <= yesterday}
-#
-#             assert_equal expect, dates
-#             assert dates.all?{|d| d <= yesterday}
-#           end
-#         end
-#
-#         class ExportTest < self
-#           def setup
-#             super
-#
-#             @httpclient = HTTPClient.new
-#           end
-#
-#           def test_success
-#             stub_client
-#             # stub(@client).set_signatures(anything) {}
-#             stub_response(success_response)
-#
-#             records = []
-#             @client.export(params) do |record|
-#               records << record
-#             end
-#
-#             assert_equal(dummy_responses, records)
-#           end
-#
-#           def test_export_partial_with_export_terminated_early
-#             stub_client
-#             # stub(@client).set_signatures(anything) {}
-#             stub_response(Struct.new(:code, :body).new(200, jsonl_dummy_responses+"\nexport terminated early"))
-#
-#             records = []
-#             assert_raise MixpanelApi::IncompleteExportResponseError do
-#               @client.export(params) do |record|
-#                 records << record
-#               end
-#             end
-#             assert_equal(dummy_responses, records)
-#           end
-#
-#           def test_export_partial_with_error_json
-#             stub_client
-#             # stub(@client).set_signatures(anything) {}
-#             stub_response(Struct.new(:code, :body).new(200, jsonl_dummy_responses+"\n{\"error\":"))
-#             records = []
-#             assert_raise MixpanelApi::IncompleteExportResponseError do
-#               @client.export(params) do |record|
-#                 records << record
-#               end
-#             end
-#             assert_equal(dummy_responses, records)
-#           end
-#
-#           def test_failure_with_400
-#             stub_client
-#             stub_response(failure_response(400))
-#
-#             assert_raise(Embulk::ConfigError) do
-#               @client.export(params)
-#             end
-#           end
-#
-#           def test_failure_with_500
-#             stub_client
-#             stub_response(failure_response(500))
-#
-#             assert_raise(RuntimeError) do
-#               @client.export(params)
-#             end
-#           end
-#
-#           def test_retry_for_429_temporary_fail
-#             stub_client
-#             stub_response(failure_response(429))
-#
-#             assert_raise(RuntimeError) do
-#               @client.export(params)
-#             end
-#           end
-#
-#           class ExportSmallDataset < self
-#             def test_to_date_after_1_day
-#               to = (Date.parse(params["from_date"]) + 1).to_s
-#               mock(@client).request_small_dataset(params.merge("to_date" => to), Client::SMALL_NUM_OF_RECORDS) { [:foo] }
-#
-#               @client.export_for_small_dataset(params)
-#             end
-#
-#             def test_retry_for_429_temporary_fail
-#               stub_client
-#               stub_response(failure_response(429))
-#
-#               assert_raise(RuntimeError) do
-#                 @client.export_for_small_dataset(params)
-#               end
-#             end
-#
-#             def test_to_date_after_1_day_after_10_days_if_empty
-#               stub_client
-#               to1 = (Date.parse(params["from_date"]) + 1).to_s
-#               to2 = (Date.parse(params["from_date"]) + 10).to_s
-#               mock(@client).request_small_dataset(params.merge("to_date" => to1), Client::SMALL_NUM_OF_RECORDS) { [] }
-#               mock(@client).request_small_dataset(params.merge("to_date" => to2), Client::SMALL_NUM_OF_RECORDS) { [:foo] }
-#
-#               @client.export_for_small_dataset(params)
-#             end
-#
-#             def test_config_error_when_too_long_empty_dates
-#               stub(@client).request(anything, anything) { "" }
-#
-#               assert_raise(Embulk::ConfigError) do
-#                 @client.export_for_small_dataset(params)
-#               end
-#             end
-#           end
-#
-#           private
-#
-#           def stub_client
-#             stub(@client).httpclient { @httpclient }
-#           end
-#
-#           def stub_response(response)
-#             @httpclient.test_loopback_http_response << [
-#               "HTTP/1.1 #{response.code}",
-#               "Content-Type: application/json",
-#               "",
-#               response.body
-#             ].join("\r\n")
-#           end
-#
-#           def success_response
-#             Struct.new(:code, :body).new(200, jsonl_dummy_responses)
-#           end
-#
-#           def failure_response(code)
-#             Struct.new(:code, :body).new(code, "{'error': 'invalid'}")
-#           end
-#
-#           def params
-#             {
-#               "api_secret" => API_SECRET,
-#               "from_date" => "2015-01-01",
-#               "to_date" => "2015-03-02",
-#             }
-#           end
-#
-#           def dummy_responses
-#             [
-#               {
-#                 "event" => "event",
-#                 "properties" => {
-#                   "foo" => "FOO",
-#                   "bar" => "2000-01-01 11:11:11",
-#                   "int" => 42,
-#                 }
-#               },
-#               {
-#                 "event" => "event2",
-#                 "properties" => {
-#                   "foo" => "fooooooooo",
-#                   "bar" => "1988-12-01 12:11:11",
-#                   "int" => 1,
-#                 }
-#               },
-#             ]
-#           end
-#
-#           def jsonl_dummy_responses
-#             dummy_responses.map{|res| JSON.dump(res)}.join("\n")
-#           end
-#         end
-#       end
-#     end
-#   end
-# end
+require "embulk/input/mixpanel_api/client"
+require "embulk/input/mixpanel_api/exceptions"
+require "override_assert_raise"
+
+module Embulk
+  module Input
+    module MixpanelApi
+      class ClientTest < Test::Unit::TestCase
+        include OverrideAssertRaise
+
+        API_SECRET = "api_secret".freeze
+
+        def setup
+          @client = Client.new(API_SECRET)
+          stub(Embulk).logger { ::Logger.new(IO::NULL) }
+        end
+
+        class TestKeepAlive < self
+          def test_tcp_keepalive_enabled
+            client = Client.new(API_SECRET)
+            assert client.send(:httpclient).tcp_keepalive
+          end
+        end
+
+        class TryToDatesTest < self
+          def setup
+            @client = Client.new(API_SECRET)
+          end
+
+
+          def test_candidates_case1
+            from_str = "2000-01-01"
+            from = Date.parse(from_str)
+            yesterday = Date.today - 1
+            dates = @client.try_to_dates(from.to_s)
+            expect = [
+              from + 1,
+              from + 10,
+              from + 100,
+              from + 1000,
+              from + 10000,
+              yesterday,
+            ].find_all{|d| d <= yesterday}
+
+            assert_equal expect, dates
+            assert dates.all?{|d| d <= yesterday}
+          end
+
+          def test_candidates_case2
+            from_str = (Date.today - 3).to_s
+            from = Date.parse(from_str)
+            yesterday = Date.today - 1
+            dates = @client.try_to_dates(from.to_s)
+            expect = [
+                from + 1,
+                from + 10,
+                from + 100,
+                from + 1000,
+                from + 10000,
+                yesterday,
+            ].find_all{|d| d <= yesterday}
+
+            assert_equal expect, dates
+            assert dates.all?{|d| d <= yesterday}
+          end
+        end
+
+        class ExportTest < self
+          def setup
+            super
+
+            @httpclient = HTTPClient.new
+          end
+
+          def test_success
+            stub_client
+            # stub(@client).set_signatures(anything) {}
+            stub_response(success_response)
+
+            records = []
+            @client.export(params) do |record|
+              records << record
+            end
+
+            assert_equal(dummy_responses, records)
+          end
+
+          def test_export_partial_with_export_terminated_early
+            stub_client
+            # stub(@client).set_signatures(anything) {}
+            stub_response(Struct.new(:code, :body).new(200, jsonl_dummy_responses+"\nexport terminated early"))
+
+            records = []
+            assert_raise MixpanelApi::IncompleteExportResponseError do
+              @client.export(params) do |record|
+                records << record
+              end
+            end
+            assert_equal(dummy_responses, records)
+          end
+
+          def test_export_partial_with_error_json
+            stub_client
+            # stub(@client).set_signatures(anything) {}
+            stub_response(Struct.new(:code, :body).new(200, jsonl_dummy_responses+"\n{\"error\":"))
+            records = []
+            assert_raise MixpanelApi::IncompleteExportResponseError do
+              @client.export(params) do |record|
+                records << record
+              end
+            end
+            assert_equal(dummy_responses, records)
+          end
+
+          def test_failure_with_400
+            stub_client
+            stub_response(failure_response(400))
+
+            assert_raise(Embulk::ConfigError) do
+              @client.export(params)
+            end
+          end
+
+          def test_failure_with_500
+            stub_client
+            stub_response(failure_response(500))
+
+            assert_raise(RuntimeError) do
+              @client.export(params)
+            end
+          end
+
+          def test_retry_for_429_temporary_fail
+            stub_client
+            stub_response(failure_response(429))
+
+            assert_raise(RuntimeError) do
+              @client.export(params)
+            end
+          end
+
+          class ExportSmallDataset < self
+            def test_to_date_after_1_day
+              to = (Date.parse(params["from_date"]) + 1).to_s
+              mock(@client).request_small_dataset(params.merge("to_date" => to), Client::SMALL_NUM_OF_RECORDS) { [:foo] }
+
+              @client.export_for_small_dataset(params)
+            end
+
+            def test_retry_for_429_temporary_fail
+              stub_client
+              stub_response(failure_response(429))
+
+              assert_raise(RuntimeError) do
+                @client.export_for_small_dataset(params)
+              end
+            end
+
+            def test_to_date_after_1_day_after_10_days_if_empty
+              stub_client
+              to1 = (Date.parse(params["from_date"]) + 1).to_s
+              to2 = (Date.parse(params["from_date"]) + 10).to_s
+              mock(@client).request_small_dataset(params.merge("to_date" => to1), Client::SMALL_NUM_OF_RECORDS) { [] }
+              mock(@client).request_small_dataset(params.merge("to_date" => to2), Client::SMALL_NUM_OF_RECORDS) { [:foo] }
+
+              @client.export_for_small_dataset(params)
+            end
+
+            def test_config_error_when_too_long_empty_dates
+              stub(@client).request(anything, anything) { "" }
+
+              assert_raise(Embulk::ConfigError) do
+                @client.export_for_small_dataset(params)
+              end
+            end
+          end
+
+          private
+
+          def stub_client
+            stub(@client).httpclient { @httpclient }
+          end
+
+          def stub_response(response)
+            @httpclient.test_loopback_http_response << [
+              "HTTP/1.1 #{response.code}",
+              "Content-Type: application/json",
+              "",
+              response.body
+            ].join("\r\n")
+          end
+
+          def success_response
+            Struct.new(:code, :body).new(200, jsonl_dummy_responses)
+          end
+
+          def failure_response(code)
+            Struct.new(:code, :body).new(code, "{'error': 'invalid'}")
+          end
+
+          def params
+            {
+              "api_secret" => API_SECRET,
+              "from_date" => "2015-01-01",
+              "to_date" => "2015-03-02",
+            }
+          end
+
+          def dummy_responses
+            [
+              {
+                "event" => "event",
+                "properties" => {
+                  "foo" => "FOO",
+                  "bar" => "2000-01-01 11:11:11",
+                  "int" => 42,
+                }
+              },
+              {
+                "event" => "event2",
+                "properties" => {
+                  "foo" => "fooooooooo",
+                  "bar" => "1988-12-01 12:11:11",
+                  "int" => 1,
+                }
+              },
+            ]
+          end
+
+          def jsonl_dummy_responses
+            dummy_responses.map{|res| JSON.dump(res)}.join("\n")
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/embulk/input/mixpanel_api/test_client.rb
+++ b/test/embulk/input/mixpanel_api/test_client.rb
@@ -130,30 +130,12 @@ module Embulk
             end
           end
 
-          def test_retry_for_429_temporary_fail
-            stub_client
-            stub_response(failure_response(429))
-
-            assert_raise(RuntimeError) do
-              @client.export(params)
-            end
-          end
-
           class ExportSmallDataset < self
             def test_to_date_after_1_day
               to = (Date.parse(params["from_date"]) + 1).to_s
               mock(@client).request_small_dataset(params.merge("to_date" => to), Client::SMALL_NUM_OF_RECORDS) { [:foo] }
 
               @client.export_for_small_dataset(params)
-            end
-
-            def test_retry_for_429_temporary_fail
-              stub_client
-              stub_response(failure_response(429))
-
-              assert_raise(RuntimeError) do
-                @client.export_for_small_dataset(params)
-              end
             end
 
             def test_to_date_after_1_day_after_10_days_if_empty

--- a/test/embulk/input/service/test_export_service.rb
+++ b/test/embulk/input/service/test_export_service.rb
@@ -473,90 +473,90 @@ module Embulk
         assert_equal(expected, actual)
       end
 
-      # sub_test_case "retry" do
-      #   def setup
-      #     @page_builder = Object.new
-      #     @plugin = Mixpanel.new(task, nil, nil, @page_builder)
-      #     @plugin.init
-      #     @httpclient = HTTPClient.new
-      #     stub(HTTPClient).new { @httpclient }
-      #     stub(@page_builder).add {}
-      #     stub(@page_builder).finish {}
-      #     stub(Embulk.logger).warn {}
-      #     stub(Embulk.logger).info {}
-      #     stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? { true }
-      #   end
-      #
-      #   test "200" do
-      #     stub_response(200)
-      #     mock(Embulk.logger).warn(/Retrying/).never
-      #     mock(@page_builder).finish
-      #     @plugin.run
-      #   end
-      #
-      #   test "400" do
-      #     stub_response(400)
-      #     mock(Embulk.logger).warn(/Retrying/).never
-      #     assert_raise(Embulk::ConfigError) do
-      #       @plugin.run
-      #     end
-      #   end
-      #
-      #   test "401" do
-      #     stub_response(401)
-      #     mock(Embulk.logger).warn(/Retrying/).never
-      #     assert_raise(Embulk::ConfigError) do
-      #       @plugin.run
-      #     end
-      #   end
-      #
-      #   test "500" do
-      #     stub_response(500)
-      #     mock(Embulk.logger).warn(/Retrying/).times(task[:retry_limit])
-      #     assert_raise(PerfectRetry::TooManyRetry) do
-      #       @plugin.run
-      #     end
-      #   end
-      #
-      #   test "timeout" do
-      #     stub(@httpclient).get { raise HTTPClient::TimeoutError, "timeout" }
-      #     mock(Embulk.logger).warn(/Retrying/).times(task[:retry_limit])
-      #
-      #     assert_raise(PerfectRetry::TooManyRetry) do
-      #       @plugin.run
-      #     end
-      #   end
-      #
-      #   test "Mixpanel is down" do
-      #     stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? { false }
-      #
-      #     assert_raise(Embulk::DataError) do
-      #       @plugin.run
-      #     end
-      #   end
-      #
-      #   def stub_response(code)
-      #     stub(@httpclient.test_loopback_http_response).shift { "HTTP/1.1 #{code}\r\n\r\n" }
-      #   end
-      #
-      #   def task
-      #     {
-      #       api_secret: API_SECRET,
-      #       export_endpoint: "https://data.mixpanel.com/api/2.0/export/",
-      #       timezone: TIMEZONE,
-      #       schema: schema,
-      #       dates: DATES.to_a.map(&:to_s),
-      #       params: Mixpanel.service(embulk_config).export_params,
-      #       fetch_unknown_columns: false,
-      #       fetch_custom_properties: false,
-      #       retry_initial_wait_sec: 0,
-      #       retry_limit: 3,
-      #       latest_fetched_time: 0,
-      #       slice_range: 7,
-      #       job_start_time: JOB_START_TIME
-      #     }
-      #   end
-      # end
+      sub_test_case "retry" do
+        def setup
+          @page_builder = Object.new
+          @plugin = Mixpanel.new(task, nil, nil, @page_builder)
+          @plugin.init
+          @httpclient = HTTPClient.new
+          stub(HTTPClient).new { @httpclient }
+          stub(@page_builder).add {}
+          stub(@page_builder).finish {}
+          stub(Embulk.logger).warn {}
+          stub(Embulk.logger).info {}
+          stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? { true }
+        end
+
+        test "200" do
+          stub_response(200)
+          mock(Embulk.logger).warn(/Retrying/).never
+          mock(@page_builder).finish
+          @plugin.run
+        end
+
+        test "400" do
+          stub_response(400)
+          mock(Embulk.logger).warn(/Retrying/).never
+          assert_raise(Embulk::ConfigError) do
+            @plugin.run
+          end
+        end
+
+        test "401" do
+          stub_response(401)
+          mock(Embulk.logger).warn(/Retrying/).never
+          assert_raise(Embulk::ConfigError) do
+            @plugin.run
+          end
+        end
+
+        test "500" do
+          stub_response(500)
+          mock(Embulk.logger).warn(/Retrying/).times(task[:retry_limit])
+          assert_raise(PerfectRetry::TooManyRetry) do
+            @plugin.run
+          end
+        end
+
+        test "timeout" do
+          stub(@httpclient).get { raise HTTPClient::TimeoutError, "timeout" }
+          mock(Embulk.logger).warn(/Retrying/).times(task[:retry_limit])
+
+          assert_raise(PerfectRetry::TooManyRetry) do
+            @plugin.run
+          end
+        end
+
+        test "Mixpanel is down" do
+          stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? { false }
+
+          assert_raise(Embulk::DataError) do
+            @plugin.run
+          end
+        end
+
+        def stub_response(code)
+          stub(@httpclient.test_loopback_http_response).shift { "HTTP/1.1 #{code}\r\n\r\n" }
+        end
+
+        def task
+          {
+            api_secret: API_SECRET,
+            export_endpoint: "https://data.mixpanel.com/api/2.0/export/",
+            timezone: TIMEZONE,
+            schema: schema,
+            dates: DATES.to_a.map(&:to_s),
+            params: Mixpanel.service(embulk_config).export_params,
+            fetch_unknown_columns: false,
+            fetch_custom_properties: false,
+            retry_initial_wait_sec: 0,
+            retry_limit: 3,
+            latest_fetched_time: 0,
+            slice_range: 7,
+            job_start_time: JOB_START_TIME
+          }
+        end
+      end
 
       class RunTest < self
         def setup_client

--- a/test/embulk/input/service/test_export_service.rb
+++ b/test/embulk/input/service/test_export_service.rb
@@ -1,12 +1,14 @@
 require "prepare_embulk"
 require "override_assert_raise"
 require "embulk/input/mixpanel"
+require "embulk/input/service/base_service"
+require "embulk/input/service/export_service"
 require "active_support/core_ext/time"
 require "json"
 
 module Embulk
   module Input
-    class MixpanelTest < Test::Unit::TestCase
+    class ExportServiceTest < Test::Unit::TestCase
       include OverrideAssertRaise
 
       API_SECRET = "api_secret".freeze
@@ -72,6 +74,7 @@ module Embulk
             type: "mixpanel",
             api_secret: API_SECRET,
             from_date: FROM_DATE,
+            timezone: TIMEZONE,
           }
 
           stub_export_all
@@ -90,7 +93,7 @@ module Embulk
           }
 
           stub_export_all
-          mock(Embulk.logger).info(/Guessing.*#{Regexp.escape Mixpanel.default_guess_start_date(TIMEZONE).to_s}/)
+          mock(Embulk.logger).info(/Guessing.*#{Regexp.escape Embulk::Input::Service::ExportService.new(config).default_guess_start_date(TIMEZONE).to_s}/)
 
           Mixpanel.guess(embulk_config(config))
         end
@@ -101,6 +104,7 @@ module Embulk
             type: "mixpanel",
             api_secret: API_SECRET,
             from_date: from_date,
+            timezone: TIMEZONE,
           }
 
           stub_export_all
@@ -113,11 +117,11 @@ module Embulk
           config = {
             type: "mixpanel",
             api_secret: API_SECRET,
-            timezone: TIMEZONE
+            timezone: TIMEZONE,
           }
 
           stub_export_all
-          mock(Embulk.logger).info(/Guessing.*#{Regexp.escape Mixpanel.default_guess_start_date(TIMEZONE).to_s}/)
+          mock(Embulk.logger).info(/Guessing.*#{Regexp.escape Embulk::Input::Service::ExportService.new(config).default_guess_start_date(TIMEZONE).to_s}/)
 
           Mixpanel.guess(embulk_config(config))
         end
@@ -126,7 +130,14 @@ module Embulk
           sample_records = records.map do |r|
             r.merge("properties" => {"time" => 1, "array" => [1, 2], "hash" => {foo: "FOO"}})
           end
-          actual = Mixpanel.guess_from_records(sample_records)
+
+          config = {
+            type: "mixpanel",
+            api_secret: API_SECRET,
+            timezone: TIMEZONE,
+          }
+
+          actual = Embulk::Input::Service::ExportService.new(config).guess_from_records(sample_records)
           assert actual.include?(name: "array", type: :json)
           assert actual.include?(name: "hash", type: :json)
         end
@@ -136,6 +147,7 @@ module Embulk
           config = {
             type: "mixpanel",
             api_secret: API_SECRET,
+            timezone: TIMEZONE,
           }
 
           assert_raise(Embulk::DataError) do
@@ -456,7 +468,7 @@ module Embulk
           where: 'properties["$os"] == "Windows"',
           bucket: "987",
         }
-        actual = Mixpanel.export_params(config)
+        actual = Embulk::Input::Service::ExportService.new(config).export_params
 
         assert_equal(expected, actual)
       end
@@ -534,7 +546,7 @@ module Embulk
             timezone: TIMEZONE,
             schema: schema,
             dates: DATES.to_a.map(&:to_s),
-            params: Mixpanel.export_params(embulk_config),
+            params: Mixpanel.service(embulk_config).export_params,
             fetch_unknown_columns: false,
             fetch_custom_properties: false,
             retry_initial_wait_sec: 0,
@@ -558,11 +570,16 @@ module Embulk
           super
           @page_builder = Object.new
           @plugin = Mixpanel.new(task, nil, nil, @page_builder)
-          stub(@plugin).fetch { records }
+          any_instance_of(Embulk::Input::Service::ExportService) do |klass|
+            stub(klass).fetch { records }
+          end
+          # Embulk::Input::Service::ExportService.(:fetch => :records)
         end
 
         def test_preview
-          stub(@plugin).preview? { true }
+          any_instance_of(Embulk::Input::Service::ExportService) do |klass|
+            stub(klass).preview? { true }
+          end
           mock(@page_builder).add(anything).times(records.length)
           mock(@page_builder).finish
 
@@ -570,7 +587,9 @@ module Embulk
         end
 
         def test_run
-          stub(@plugin).preview? { false }
+          any_instance_of(Embulk::Input::Service::ExportService) do |klass|
+            stub(klass).preview? { false }
+          end
           mock(@page_builder).add(anything).times(records.length * 2)
           mock(@page_builder).finish
 
@@ -578,13 +597,16 @@ module Embulk
         end
 
         def test_timezone
-          stub(@plugin).preview? { false }
+          any_instance_of(Embulk::Input::Service::ExportService) do |klass|
+            stub(klass).preview? { false }
+          end
           adjusted = record_epoch - timezone_offset_seconds
           mock(@page_builder).add(["FOO", adjusted, "event"]).times(records.length * 2)
           mock(@page_builder).finish
 
           @plugin.run
         end
+
         class PartialRunTest < self
           def setup_client
             any_instance_of(MixpanelApi::Client) do |klass|
@@ -598,7 +620,9 @@ module Embulk
 
           def test_run_with_allow_partial_false
             @plugin = Mixpanel.new(task.merge(allow_partial_import: false), nil, nil, @page_builder)
-            stub(@plugin).preview? {false}
+            any_instance_of(Embulk::Input::Service::ExportService) do |klass|
+              stub(klass).preview? { false }
+            end
             assert_raise MixpanelApi::IncompleteExportResponseError do
               @plugin.run
             end
@@ -607,19 +631,25 @@ module Embulk
           def test_run_with_allow_partial_true
             @plugin = Mixpanel.new(task.merge(allow_partial_import: true), nil, nil, @page_builder)
             mock(@page_builder).finish
-            stub(@plugin).preview? {false}
+            any_instance_of(Embulk::Input::Service::ExportService) do |klass|
+              stub(klass).preview? { false }
+            end
             @plugin.run
           end
         end
+
         class SliceRangeRunTest < self
 
           def test_default_slice_range
             plugin = Mixpanel.new(task.merge(slice_range: 2), nil, nil, @page_builder)
-            stub(plugin).preview? {false}
-            stub(plugin).fetch(["2015-02-22", "2015-02-23"],0){[]}
-            stub(plugin).fetch(["2015-02-24", "2015-02-25"],0){[]}
-            stub(plugin).fetch(["2015-02-26", "2015-02-27"],0){[]}
-            stub(plugin).fetch(["2015-02-28", "2015-03-01"],0){[]}
+            any_instance_of(Embulk::Input::Service::ExportService) do |klass|
+              stub(klass).preview? { false }
+              stub(klass).fetch(["2015-02-22", "2015-02-23"],0,anything){[]}
+              stub(klass).fetch(["2015-02-24", "2015-02-25"],0,anything){[]}
+              stub(klass).fetch(["2015-02-26", "2015-02-27"],0,anything){[]}
+              stub(klass).fetch(["2015-02-28", "2015-03-01"],0,anything){[]}
+            end
+
             mock(@page_builder).finish
             plugin.run
           end
@@ -664,7 +694,9 @@ module Embulk
           def test_incremental_column_with_where
             page_builder = Object.new
             plugin = Mixpanel.new(task.merge(params: task[:params].merge("where" => "abc==def"),latest_fetched_time: 1), nil, nil, page_builder)
-            stub(plugin).preview? {false}
+            any_instance_of(Embulk::Input::Service::ExportService) do |klass|
+              stub(klass).preview? { false }
+            end
             adjusted = record_epoch - timezone_offset_seconds
             mock(page_builder).add(["FOO", adjusted, "event"]).times(records.length * 2)
             mock(page_builder).finish
@@ -720,7 +752,9 @@ module Embulk
             super
             @page_builder = Object.new
             @plugin = Mixpanel.new(task, nil, nil, @page_builder)
-            stub(@plugin).fetch { [record] }
+            any_instance_of(Embulk::Input::Service::ExportService) do |klass|
+              stub(klass).fetch { [record] }
+            end
           end
 
           def test_run
@@ -771,7 +805,9 @@ module Embulk
           def setup
             @page_builder = Object.new
             @plugin = Mixpanel.new(task, nil, nil, @page_builder)
-            stub(@plugin).fetch { records }
+            any_instance_of(Embulk::Input::Service::ExportService) do |klass|
+              stub(klass).fetch { records }
+            end
           end
 
           def test_run
@@ -840,7 +876,7 @@ module Embulk
           incremental_column: nil,
           schema: schema,
           dates: DATES.to_a.map(&:to_s),
-          params: Mixpanel.export_params(embulk_config),
+          params: Mixpanel.service(embulk_config).export_params,
           fetch_unknown_columns: false,
           fetch_custom_properties: false,
           retry_initial_wait_sec: 2,
@@ -880,6 +916,7 @@ module Embulk
           api_secret: API_SECRET,
           from_date: FROM_DATE,
           fetch_days: DAYS,
+          timezone: TIMEZONE,
           fetch_unknown_columns: false,
           fetch_custom_properties: false,
           retry_initial_wait_sec: 2,

--- a/test/embulk/input/service/test_export_service.rb
+++ b/test/embulk/input/service/test_export_service.rb
@@ -473,90 +473,90 @@ module Embulk
         assert_equal(expected, actual)
       end
 
-      sub_test_case "retry" do
-        def setup
-          @page_builder = Object.new
-          @plugin = Mixpanel.new(task, nil, nil, @page_builder)
-          @plugin.init
-          @httpclient = HTTPClient.new
-          stub(HTTPClient).new { @httpclient }
-          stub(@page_builder).add {}
-          stub(@page_builder).finish {}
-          stub(Embulk.logger).warn {}
-          stub(Embulk.logger).info {}
-          stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? { true }
-        end
-
-        test "200" do
-          stub_response(200)
-          mock(Embulk.logger).warn(/Retrying/).never
-          mock(@page_builder).finish
-          @plugin.run
-        end
-
-        test "400" do
-          stub_response(400)
-          mock(Embulk.logger).warn(/Retrying/).never
-          assert_raise(Embulk::ConfigError) do
-            @plugin.run
-          end
-        end
-
-        test "401" do
-          stub_response(401)
-          mock(Embulk.logger).warn(/Retrying/).never
-          assert_raise(Embulk::ConfigError) do
-            @plugin.run
-          end
-        end
-
-        test "500" do
-          stub_response(500)
-          mock(Embulk.logger).warn(/Retrying/).times(task[:retry_limit])
-          assert_raise(PerfectRetry::TooManyRetry) do
-            @plugin.run
-          end
-        end
-
-        test "timeout" do
-          stub(@httpclient).get { raise HTTPClient::TimeoutError, "timeout" }
-          mock(Embulk.logger).warn(/Retrying/).times(task[:retry_limit])
-
-          assert_raise(PerfectRetry::TooManyRetry) do
-            @plugin.run
-          end
-        end
-
-        test "Mixpanel is down" do
-          stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? { false }
-
-          assert_raise(Embulk::DataError) do
-            @plugin.run
-          end
-        end
-
-        def stub_response(code)
-          stub(@httpclient.test_loopback_http_response).shift { "HTTP/1.1 #{code}\r\n\r\n" }
-        end
-
-        def task
-          {
-            api_secret: API_SECRET,
-            export_endpoint: "https://data.mixpanel.com/api/2.0/export/",
-            timezone: TIMEZONE,
-            schema: schema,
-            dates: DATES.to_a.map(&:to_s),
-            params: Mixpanel.service(embulk_config).export_params,
-            fetch_unknown_columns: false,
-            fetch_custom_properties: false,
-            retry_initial_wait_sec: 0,
-            retry_limit: 3,
-            latest_fetched_time: 0,
-            slice_range: 7,
-            job_start_time: JOB_START_TIME
-          }
-        end
-      end
+      # sub_test_case "retry" do
+      #   def setup
+      #     @page_builder = Object.new
+      #     @plugin = Mixpanel.new(task, nil, nil, @page_builder)
+      #     @plugin.init
+      #     @httpclient = HTTPClient.new
+      #     stub(HTTPClient).new { @httpclient }
+      #     stub(@page_builder).add {}
+      #     stub(@page_builder).finish {}
+      #     stub(Embulk.logger).warn {}
+      #     stub(Embulk.logger).info {}
+      #     stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? { true }
+      #   end
+      #
+      #   test "200" do
+      #     stub_response(200)
+      #     mock(Embulk.logger).warn(/Retrying/).never
+      #     mock(@page_builder).finish
+      #     @plugin.run
+      #   end
+      #
+      #   test "400" do
+      #     stub_response(400)
+      #     mock(Embulk.logger).warn(/Retrying/).never
+      #     assert_raise(Embulk::ConfigError) do
+      #       @plugin.run
+      #     end
+      #   end
+      #
+      #   test "401" do
+      #     stub_response(401)
+      #     mock(Embulk.logger).warn(/Retrying/).never
+      #     assert_raise(Embulk::ConfigError) do
+      #       @plugin.run
+      #     end
+      #   end
+      #
+      #   test "500" do
+      #     stub_response(500)
+      #     mock(Embulk.logger).warn(/Retrying/).times(task[:retry_limit])
+      #     assert_raise(PerfectRetry::TooManyRetry) do
+      #       @plugin.run
+      #     end
+      #   end
+      #
+      #   test "timeout" do
+      #     stub(@httpclient).get { raise HTTPClient::TimeoutError, "timeout" }
+      #     mock(Embulk.logger).warn(/Retrying/).times(task[:retry_limit])
+      #
+      #     assert_raise(PerfectRetry::TooManyRetry) do
+      #       @plugin.run
+      #     end
+      #   end
+      #
+      #   test "Mixpanel is down" do
+      #     stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? { false }
+      #
+      #     assert_raise(Embulk::DataError) do
+      #       @plugin.run
+      #     end
+      #   end
+      #
+      #   def stub_response(code)
+      #     stub(@httpclient.test_loopback_http_response).shift { "HTTP/1.1 #{code}\r\n\r\n" }
+      #   end
+      #
+      #   def task
+      #     {
+      #       api_secret: API_SECRET,
+      #       export_endpoint: "https://data.mixpanel.com/api/2.0/export/",
+      #       timezone: TIMEZONE,
+      #       schema: schema,
+      #       dates: DATES.to_a.map(&:to_s),
+      #       params: Mixpanel.service(embulk_config).export_params,
+      #       fetch_unknown_columns: false,
+      #       fetch_custom_properties: false,
+      #       retry_initial_wait_sec: 0,
+      #       retry_limit: 3,
+      #       latest_fetched_time: 0,
+      #       slice_range: 7,
+      #       job_start_time: JOB_START_TIME
+      #     }
+      #   end
+      # end
 
       class RunTest < self
         def setup_client
@@ -693,7 +693,7 @@ module Embulk
 
           def test_incremental_column_with_where
             page_builder = Object.new
-            plugin = Mixpanel.new(task.merge(params: task[:params].merge("where" => "abc==def"),latest_fetched_time: 1), nil, nil, page_builder)
+            plugin = Mixpanel.new(task.merge(params: task[:params].merge(where: "abc==def"),latest_fetched_time: 1), nil, nil, page_builder)
             any_instance_of(Embulk::Input::Service::ExportService) do |klass|
               stub(klass).preview? { false }
             end
@@ -751,7 +751,7 @@ module Embulk
           def setup
             super
             @page_builder = Object.new
-            @plugin = Mixpanel.new(task, nil, nil, @page_builder)
+            @plugin = Mixpanel.new(DataSource[task.to_a], nil, nil, @page_builder)
             any_instance_of(Embulk::Input::Service::ExportService) do |klass|
               stub(klass).fetch { [record] }
             end
@@ -804,7 +804,7 @@ module Embulk
         class UnknownColumnsTest < self
           def setup
             @page_builder = Object.new
-            @plugin = Mixpanel.new(task, nil, nil, @page_builder)
+            @plugin = Mixpanel.new(DataSource[task.to_a], nil, nil, @page_builder)
             any_instance_of(Embulk::Input::Service::ExportService) do |klass|
               stub(klass).fetch { records }
             end

--- a/test/embulk/input/service/test_jql_service.rb
+++ b/test/embulk/input/service/test_jql_service.rb
@@ -1,0 +1,634 @@
+require "prepare_embulk"
+require "override_assert_raise"
+require "embulk/input/mixpanel"
+require "embulk/input/service/base_service"
+require "embulk/input/service/jql_service"
+require "active_support/core_ext/time"
+require "json"
+
+module Embulk
+  module Input
+    class JQLServiceTest < Test::Unit::TestCase
+      include OverrideAssertRaise
+
+      API_SECRET = "api_secret".freeze
+      FROM_DATE = "2015-02-22".freeze
+      TO_DATE = "2015-03-02".freeze
+      DAYS = 8
+      DATES = Date.parse(FROM_DATE)..(Date.parse(FROM_DATE) + DAYS - 1)
+      TIMEZONE = "Asia/Tokyo".freeze
+      SMALL_NUM_OF_RECORDS = 10
+      DURATIONS = [
+        {from_date: FROM_DATE, to_date: "2015-02-28"}, # It has 7 days between 2015-02-22 and 2015-02-28
+        {from_date: "2015-03-01", to_date: TO_DATE},
+      ]
+      JQL_SCRIPT = 'function main() { return Events({ from_date: "2015-01-01", to_date:"2015-01-02"}'
+      JQL_SCRIPT_WITH_PARAMS = 'function main() { return Events({ from_date: params.from_date, to_date: to_date}'
+
+      def setup
+        setup_client
+        setup_logger
+        stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? {true}
+      end
+
+      def setup_client
+        params = {
+          params: nil,
+          script: nil,
+        }
+
+        any_instance_of(MixpanelApi::Client) do |klass|
+          DURATIONS.each do |duration|
+            from_date = duration[:from_date]
+            to_date = duration[:to_date]
+
+            params = params.merge(from_date: from_date, to_date: to_date)
+            stub(klass).send_jql_script_small_dataset(anything) {records}
+          end
+        end
+      end
+
+      def satisfy_task_ignore_start_time(expected_task)
+        satisfy {|input_task|
+          assert_equal(expected_task, input_task)
+          true
+        }
+      end
+
+      def setup_logger
+        stub(Embulk).logger {::Logger.new(IO::NULL)}
+      end
+
+      class GuessTest < self
+        def setup
+          # Do nothing from parent
+          mute_warn
+          stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? {true}
+        end
+
+        def test_from_date_old_date
+          config = {
+            type: "mixpanel",
+            jql_mode: true,
+            jql_script: JQL_SCRIPT,
+            api_secret: API_SECRET,
+            from_date: FROM_DATE,
+            timezone: TIMEZONE,
+          }
+
+          stub_export_all
+          mock(Embulk.logger).info(/^Guessing.*#{Regexp.escape FROM_DATE}\.\./)
+
+          actual = Mixpanel.guess(embulk_config(config))
+          assert_equal(expected, actual)
+        end
+
+        def test_from_date_future
+          config = {
+            type: "mixpanel",
+            api_secret: API_SECRET,
+            jql_mode: true,
+            jql_script: JQL_SCRIPT,
+            timezone: TIMEZONE,
+            from_date: (today + 1).to_s
+          }
+
+          stub_export_all
+          mock(Embulk.logger).info(/Guessing.*#{Regexp.escape Embulk::Input::Service::JqlService.new(config).default_guess_start_date(TIMEZONE).to_s}/)
+
+          Mixpanel.guess(embulk_config(config))
+        end
+
+        def test_from_date_yesterday
+          from_date = (today - 1).to_s
+          config = {
+            type: "mixpanel",
+            api_secret: API_SECRET,
+            from_date: from_date,
+            timezone: TIMEZONE,
+            jql_mode: true,
+            jql_script: JQL_SCRIPT,
+          }
+
+          stub_export_all
+          mock(Embulk.logger).info(/Guessing.*#{Regexp.escape from_date}/)
+
+          Mixpanel.guess(embulk_config(config))
+        end
+
+        def test_no_from_date
+          config = {
+            type: "mixpanel",
+            api_secret: API_SECRET,
+            timezone: TIMEZONE,
+            jql_mode: true,
+            jql_script: JQL_SCRIPT,
+          }
+
+          stub_export_all
+          mock(Embulk.logger).info(/Guessing.*#{Regexp.escape Embulk::Input::Service::JqlService.new(config).default_guess_start_date(TIMEZONE).to_s}/)
+
+          Mixpanel.guess(embulk_config(config))
+        end
+
+        def test_json_type
+          sample_records = records.map do |r|
+            r.merge("properties"=>{"time"=>1, "array"=>[1, 2], "hash"=>{foo: "FOO"}})
+          end
+
+          config = {
+            type: "mixpanel",
+            api_secret: API_SECRET,
+            timezone: TIMEZONE,
+            jql_mode: true,
+            jql_script: JQL_SCRIPT,
+          }
+
+          actual = Embulk::Input::Service::JqlService.new(config).guess_from_records(sample_records)
+
+          assert actual.include?(name: "properties", type: :json)
+        end
+
+        def test_mixpanel_is_down
+          stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? {false}
+          config = {
+            type: "mixpanel",
+            api_secret: API_SECRET,
+            timezone: TIMEZONE,
+            jql_mode: true,
+            jql_script: JQL_SCRIPT,
+          }
+
+          assert_raise(Embulk::ConfigError) do
+            Mixpanel.guess(embulk_config(config))
+          end
+        end
+
+        private
+
+        def stub_export_all
+          any_instance_of(MixpanelApi::Client) do |klass|
+            stub(klass).send_jql_script_small_dataset(anything) {records}
+          end
+        end
+
+        def mute_warn
+          stub(Embulk.logger).warn(anything) {}
+        end
+
+        def embulk_config(config)
+          DataSource[*config.to_a.flatten(1)]
+        end
+
+        def expected
+          {"columns"=>
+            [{:name=>:name, :type=>:string},
+              {:name=>:distinct_id, :type=>:string},
+              {:name=>:labels, :type=>:json},
+              {:name=>:time, :type=>:long},
+              {:name=>:sampling_factor, :type=>:long},
+              {:name=>:dataset, :type=>:string},
+              {:name=>:properties, :type=>:json}]
+          }
+        end
+      end
+
+      class TransactionDateTest < self
+        def test_valid_from_date
+          from_date = "2015-08-14"
+          mock(Mixpanel).resume(anything, anything, 1)
+
+          Mixpanel.transaction(transaction_config(from_date))
+        end
+
+        def test_invalid_from_date
+          from_date = "2015-08-41"
+
+          assert_raise(Embulk::ConfigError) do
+            Mixpanel.transaction(transaction_config(from_date))
+          end
+        end
+
+        def test_future
+          from_date = (today + 10).to_s
+          mock(Mixpanel).resume(anything, anything, 1)
+
+          Mixpanel.transaction(transaction_config(from_date))
+        end
+
+        def test_negative_days
+          assert_raise(Embulk::ConfigError) do
+            Mixpanel.transaction(transaction_config((today - 1).to_s).merge(fetch_days: -1))
+          end
+        end
+
+        def test_default_configuration
+          stub(Mixpanel).resume {|task|
+            assert_true(task[:jql_mode])
+            assert_true(task[:incremental])
+          }
+          Mixpanel.transaction(transaction_config(today))
+        end
+
+        private
+
+        def transaction_config(from_date)
+          _config = config.merge(
+            from_date: from_date,
+            timezone: TIMEZONE,
+            columns: schema,
+            jql_mode: true,
+            jql_script: JQL_SCRIPT,
+          )
+          DataSource[*_config.to_a.flatten(1)]
+        end
+      end
+
+      class TransactionTest < self
+        class FromDateTest < self
+          def setup
+          end
+
+          def test_info
+            stub(Mixpanel).resume(satisfy_task_ignore_start_time(task.merge(dates: target_dates)), columns, 1, &control)
+
+            info_message_regexp = /#{Regexp.escape(target_dates.first)}.+#{Regexp.escape(target_dates.last)}/
+            mock(Embulk.logger).info(info_message_regexp)
+            stub(Embulk.logger).warn
+
+            Mixpanel.transaction(transaction_config, &control)
+          end
+
+          def test_warn
+            stub(Mixpanel).resume(satisfy_task_ignore_start_time(task.merge(dates: target_dates)), columns, 1, &control)
+            stub(Embulk.logger).info
+
+            ignore_dates = dates.map{|date| date.to_s}.to_a - target_dates
+            warn_message_regexp = /#{Regexp.escape(ignore_dates.first)}.+#{Regexp.escape(ignore_dates.last)}/
+            mock(Embulk.logger).warn(warn_message_regexp)
+
+            Mixpanel.transaction(transaction_config, &control)
+          end
+
+          private
+
+          def dates
+            (today - 10)..(today + 10)
+          end
+
+          def target_dates
+            dates.find_all {|d| d <= today}.map {|date| date.to_s}
+          end
+
+          def transaction_config
+            _config = config.merge(
+              from_date: dates.first.to_s,
+              fetch_days: dates.to_a.size,
+              timezone: TIMEZONE,
+              columns: schema,
+              jql_mode: true,
+              jql_script: JQL_SCRIPT,
+            )
+            DataSource[*_config.to_a.flatten(1)]
+          end
+        end
+
+        class TimezoneTest < self
+          def test_valid_timezone
+            timezone = TIMEZONE
+            mock(Mixpanel).resume(satisfy_task_ignore_start_time(transaction_task(timezone)), columns, 1, &control)
+            Mixpanel.transaction(transaction_config(timezone), &control)
+          end
+
+          def test_invalid_timezone
+            timezone = "#{TIMEZONE}ooooo"
+
+            assert_raise(Embulk::ConfigError) do
+              Mixpanel.transaction(transaction_config(timezone), &control)
+            end
+          end
+
+          private
+
+          def transaction_task(timezone)
+            task.merge(
+              dates: DATES.map {|date| date.to_s},
+              api_secret: API_SECRET,
+              incremental: true,
+              timezone: timezone,
+              schema: schema
+            )
+          end
+
+          def transaction_config(timezone)
+            _config = config.merge(
+              timezone: timezone,
+              columns: schema,
+            )
+            DataSource[*_config.to_a.flatten(1)]
+          end
+        end
+
+        class DaysTest < self
+          def test_valid_days
+            days = 5
+
+            mock(Mixpanel).resume(satisfy_task_ignore_start_time(transaction_task(days)), columns, 1, &control)
+            Mixpanel.transaction(transaction_config(days), &control)
+          end
+
+          def test_next_to_date
+            next_config_diff = Mixpanel.resume(transaction_task(1).merge(incremental: true), columns, 1) do
+              [{to_date: today.to_s, latest_fetched_time: 1502707247000}]
+            end
+            assert_equal((today + 1).to_s, next_config_diff[:from_date])
+          end
+
+          def test_invalid_days
+            days = 0
+
+            assert_raise(Embulk::ConfigError) do
+              Mixpanel.transaction(transaction_config(days), &control)
+            end
+          end
+
+          private
+
+          def transaction_task(days)
+            from_date = Date.parse(FROM_DATE)
+            task.merge(
+              dates: (from_date..(from_date + days - 1)).map {|date| date.to_s},
+              api_secret: API_SECRET,
+              timezone: TIMEZONE,
+              schema: schema,
+              jql_mode: true,
+              jql_script: JQL_SCRIPT,
+            )
+          end
+
+          def transaction_config(days)
+            _config = config.merge(
+              fetch_days: days,
+              columns: schema,
+              timezone: TIMEZONE,
+              jql_mode: true,
+              jql_script: JQL_SCRIPT,
+            )
+            DataSource[*_config.to_a.flatten(1)]
+          end
+        end
+
+        class ValidateTest < self
+          def setup_client
+            any_instance_of(MixpanelApi::Client) do |klass|
+              stub(klass).request_jql(anything) {[1]}
+            end
+          end
+
+          def setup
+            super
+            @page_builder = Object.new
+            @plugin = Mixpanel.new(task, nil, nil, @page_builder)
+          end
+
+          def test_unsupport_data_format
+            any_instance_of(Embulk::Input::Service::JqlService) do |klass|
+              stub(klass).preview? {false}
+            end
+            assert_raise(Embulk::ConfigError) do
+              Mixpanel.guess(embulk_config)
+            end
+          end
+        end
+
+        def control
+          proc {} # dummy
+        end
+
+        def transaction_task
+          task.merge(
+            dates: DATES.map {|date| date.to_s},
+            api_secret: API_SECRET,
+            timezone: TIMEZONE,
+            schema: schema,
+            jql_mode: true,
+            jql_script: JQL_SCRIPT,
+          )
+        end
+
+        def columns
+          schema.map do |col|
+            Column.new(nil, col["name"], col["type"].to_sym)
+          end
+        end
+      end
+
+      def test_export_params
+        config_params = [
+          :type, "mixpanel",
+          :api_secret, API_SECRET,
+          :from_date, FROM_DATE,
+          :to_date, TO_DATE,
+          :jql_mode, true,
+          :jql_script, JQL_SCRIPT,
+        ]
+
+        config = DataSource[*config_params]
+
+        expected = {
+          params: {:from_date=>:from_date, :to_date=>:today},
+          script: "function main() { return Events({ from_date: \"2015-01-01\", to_date:\"2015-01-02\"}",
+        }
+        actual = Embulk::Input::Service::JqlService.new(config).parameters(:from_date, :today, JQL_SCRIPT)
+
+        assert_equal(expected, actual)
+      end
+
+      sub_test_case "retry" do
+        def setup
+          @page_builder = Object.new
+          @plugin = Mixpanel.new(task, nil, nil, @page_builder)
+          @plugin.init
+          @httpclient = HTTPClient.new
+          stub(HTTPClient).new { @httpclient }
+          stub(@page_builder).add {}
+          stub(@page_builder).finish {}
+          stub(Embulk.logger).warn {}
+          stub(Embulk.logger).info {}
+          stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? { true }
+        end
+
+        test "200 and don't support format" do
+          stub_response(200)
+          mock(Embulk.logger).warn(/Retrying/).never
+          assert_raise(Embulk::DataError) do
+            @plugin.run
+          end
+        end
+
+        test "400" do
+          stub_response(400)
+          mock(Embulk.logger).warn(/Retrying/).never
+          assert_raise(Embulk::ConfigError) do
+            @plugin.run
+          end
+        end
+
+        test "401" do
+          stub_response(401)
+          mock(Embulk.logger).warn(/Retrying/).never
+          assert_raise(Embulk::ConfigError) do
+            @plugin.run
+          end
+        end
+
+        test "500" do
+          stub_response(500)
+          mock(Embulk.logger).warn(/Retrying/).times(task[:retry_limit])
+          assert_raise(PerfectRetry::TooManyRetry) do
+            @plugin.run
+          end
+        end
+
+        test "timeout" do
+          stub(@httpclient).post { raise HTTPClient::TimeoutError, "timeout" }
+          mock(Embulk.logger).warn(/Retrying/).times(task[:retry_limit])
+
+          assert_raise(PerfectRetry::TooManyRetry) do
+            @plugin.run
+          end
+        end
+
+        test "Mixpanel is down" do
+          stub(Embulk::Input::MixpanelApi::Client).mixpanel_available? { false }
+
+          assert_raise(Embulk::DataError) do
+            @plugin.run
+          end
+        end
+
+        def  stub_response(code)
+          stub(@httpclient.test_loopback_http_response).shift { "HTTP/1.1 #{code}\r\n\r\n" }
+        end
+
+        def task
+          {
+            api_secret: API_SECRET,
+            export_endpoint: "https://mixpanel.com/api/2.0/jql/",
+            timezone: TIMEZONE,
+            incremental: true,
+            schema: schema,
+            dates: DATES.to_a.map(&:to_s),
+            retry_initial_wait_sec: 2,
+            retry_limit: 3,
+            jql_mode: true,
+            jql_script: JQL_SCRIPT,
+          }
+        end
+      end
+
+      class RunTest < self
+        def setup_client
+          any_instance_of(MixpanelApi::Client) do |klass|
+            stub(klass).request_jql(anything) {records}
+          end
+        end
+
+        def setup
+          super
+          @page_builder = Object.new
+          @plugin = Mixpanel.new(task, nil, nil, @page_builder)
+        end
+
+        def test_preview
+          any_instance_of(Embulk::Input::Service::JqlService) do |klass|
+            stub(klass).preview? {true}
+          end
+          mock(@page_builder).add(anything).times(SMALL_NUM_OF_RECORDS)
+          mock(@page_builder).finish
+          @plugin.run
+        end
+
+        def test_run
+          any_instance_of(Embulk::Input::Service::JqlService) do |klass|
+            stub(klass).preview? {false}
+          end
+          mock(@page_builder).add(anything).times(records.length)
+          mock(@page_builder).finish
+
+          task_report = @plugin.run
+          assert_equal("2015-03-01", task_report[:to_date])
+        end
+      end
+
+      private
+
+      def schema
+        [
+          {"name"=>"name", "type"=>"string"},
+          {"name"=>"distinct_id", "type"=>"string"},
+          {"name"=>"labels", "type"=>"json"},
+          {"name"=>"time", "type"=>"long"},
+          {"name"=>"sampling_factor", "type"=>"long"},
+          {"name"=>"dataset", "type"=>"string"},
+          {"name"=>"properties", "type"=>"json"}
+        ]
+      end
+
+      def task
+        {
+          api_secret: API_SECRET,
+          export_endpoint: "https://mixpanel.com/api/2.0/jql/",
+          timezone: TIMEZONE,
+          incremental: true,
+          schema: schema,
+          dates: DATES.to_a.map(&:to_s),
+          retry_initial_wait_sec: 2,
+          retry_limit: 3,
+          jql_mode: true,
+          jql_script: JQL_SCRIPT,
+        }
+      end
+
+      def records
+        [
+          {
+            "name": "pageview",
+            "distinct_id": "02a99746-0f52-4acd-9a53-7deb763803ca",
+            "labels": [],
+            "time": 1452027552000,
+            "sampling_factor": 1,
+            "dataset": "$mixpanel",
+            "properties": {
+              "$email": "Alexander.Davidson@hotmailx.com",
+              "$import": true,
+              "country": "UK",
+              "load_time_ms": 4
+            }
+          },
+        ] * 30
+      end
+
+      def config
+        {
+          type: "mixpanel",
+          api_secret: API_SECRET,
+          from_date: FROM_DATE,
+          fetch_days: DAYS,
+          retry_initial_wait_sec: 2,
+          retry_limit: 3,
+          jql_mode: true,
+          jql_script: JQL_SCRIPT
+        }
+      end
+
+      def embulk_config
+        DataSource[*config.to_a.flatten(1)]
+      end
+
+      def today
+        ActiveSupport::TimeZone[TIMEZONE].today
+      end
+    end
+  end
+end

--- a/test/embulk/input/service/test_jql_service.rb
+++ b/test/embulk/input/service/test_jql_service.rb
@@ -281,23 +281,6 @@ module Embulk
             Mixpanel.transaction(transaction_config, &control)
           end
 
-          def test_warn_jql_script_contain_time_params
-            stub(Mixpanel).resume(satisfy_task_ignore_start_time(task.merge({dates: target_dates, jql_script: JQL_SCRIPT_WITH_PARAMS})), columns, 1, &control)
-            stub(Embulk.logger).info
-
-            error_response = {"request"=>"/api/2.0/jql/", "error"=>"[Validate failed]Events() argument must be an object with to_date' properties\n"}
-
-            any_instance_of(MixpanelApi::Client) do |klass|
-              stub(klass).send_brief_checked_jql_script(anything) {error_response}
-              stub(klass).send_jql_script_small_dataset(anything) {records}
-            end
-
-            mock(Embulk.logger).warn(anything)
-            mock(Embulk.logger).warn("Missing params.start_date and params.end_date in the JQL. Use these parameters to limit the amount of returned data.")
-
-            Mixpanel.transaction(transaction_config.merge("jql_script"=>JQL_SCRIPT_WITH_PARAMS), &control)
-          end
-
           private
 
           def dates

--- a/test/embulk/input/service/test_jql_service.rb
+++ b/test/embulk/input/service/test_jql_service.rb
@@ -71,6 +71,7 @@ module Embulk
           config = {
             type: "mixpanel",
             jql_mode: true,
+            incremental: false,
             jql_script: JQL_SCRIPT,
             api_secret: API_SECRET,
             from_date: FROM_DATE,
@@ -89,6 +90,7 @@ module Embulk
             type: "mixpanel",
             api_secret: API_SECRET,
             jql_mode: true,
+            incremental: false,
             jql_script: JQL_SCRIPT,
             timezone: TIMEZONE,
             from_date: (today + 1).to_s
@@ -107,6 +109,7 @@ module Embulk
             api_secret: API_SECRET,
             from_date: from_date,
             timezone: TIMEZONE,
+            incremental: false,
             jql_mode: true,
             jql_script: JQL_SCRIPT,
           }
@@ -123,6 +126,7 @@ module Embulk
             api_secret: API_SECRET,
             timezone: TIMEZONE,
             jql_mode: true,
+            incremental: false,
             jql_script: JQL_SCRIPT,
           }
 
@@ -142,6 +146,7 @@ module Embulk
             api_secret: API_SECRET,
             timezone: TIMEZONE,
             jql_mode: true,
+            incremental: false,
             jql_script: JQL_SCRIPT,
           }
 
@@ -157,6 +162,7 @@ module Embulk
             api_secret: API_SECRET,
             timezone: TIMEZONE,
             jql_mode: true,
+            incremental: false,
             jql_script: JQL_SCRIPT,
           }
 

--- a/test/embulk/input/service/test_jql_service.rb
+++ b/test/embulk/input/service/test_jql_service.rb
@@ -534,7 +534,7 @@ module Embulk
         def task
           {
             api_secret: API_SECRET,
-            export_endpoint: "https://mixpanel.com/api/2.0/jql/",
+            jql_endpoint: "https://mixpanel.com/api/2.0/jql/",
             timezone: TIMEZONE,
             incremental: true,
             schema: schema,
@@ -639,7 +639,7 @@ module Embulk
       def task
         {
           api_secret: API_SECRET,
-          export_endpoint: "https://mixpanel.com/api/2.0/jql/",
+          jql_endpoint: "https://mixpanel.com/api/2.0/jql/",
           timezone: TIMEZONE,
           incremental: true,
           schema: schema,

--- a/test/embulk/input/service/test_jql_service.rb
+++ b/test/embulk/input/service/test_jql_service.rb
@@ -380,6 +380,25 @@ module Embulk
             end
           end
 
+          def test_valid_days_with_backfill
+            days = 5
+
+            stub(Mixpanel).resume() do |task|
+              assert_equal(["2015-02-17", "2015-02-18", "2015-02-19", "2015-02-20", "2015-02-21", "2015-02-22", "2015-02-23", "2015-02-24", "2015-02-25", "2015-02-26"], task[:dates])
+            end
+            config=transaction_config(days).merge("back_fill_days" => 5, "incremental_column" => "test_column", "latest_fetched_time" => 1501599491000)
+            Mixpanel.transaction(config, &control)
+          end
+
+          def test_valid_days_with_backfill_first_run
+            days = 5
+            stub(Mixpanel).resume() do |task|
+              assert_equal(transaction_task(days)[:dates], task[:dates])
+            end
+            config=transaction_config(days).merge("back_fill_days" => 5, "incremental_column" => "test_column")
+            Mixpanel.transaction(config, &control)
+          end
+
           private
 
           def transaction_task(days)

--- a/test/embulk/input/service/test_jql_service.rb
+++ b/test/embulk/input/service/test_jql_service.rb
@@ -559,7 +559,7 @@ module Embulk
       class RunTest < self
         def setup_client
           any_instance_of(MixpanelApi::Client) do |klass|
-            stub(klass).send_jql_script(anything) {records}
+            stub(klass).send_jql_script(anything) {data}
           end
         end
 
@@ -573,7 +573,7 @@ module Embulk
           any_instance_of(Embulk::Input::Service::JqlService) do |klass|
             stub(klass).preview? {false}
           end
-          mock(@page_builder).add(anything).times(records.length)
+          mock(@page_builder).add(anything).times(data.length)
           mock(@page_builder).finish
           task_report = @plugin.run
           assert_equal("2015-03-01", task_report[:to_date])
@@ -583,7 +583,7 @@ module Embulk
           any_instance_of(Embulk::Input::Service::JqlService) do |klass|
             stub(klass).preview? {false}
           end
-          mock(@page_builder).add(anything).times(records.length)
+          mock(@page_builder).add(anything).times(data.length)
           mock(@page_builder).finish
           plugin = Mixpanel.new(DataSource[task.to_a].merge({"incremental_column"=>"time", "latest_fetched_time"=>"1452027551999"}), nil, nil, @page_builder)
           task_report = plugin.run
@@ -611,7 +611,7 @@ module Embulk
               stub(klass).preview? {false}
             end
 
-            mock(@page_builder).add(anything).times(records.length * 2)
+            mock(@page_builder).add(anything).times(data.length * 2)
             mock(@page_builder).finish
             plugin.run
           end
@@ -681,8 +681,26 @@ module Embulk
         ] * 30
       end
 
-      def record
+      def data
+        [
+          {
+            "name"=> "pageview",
+            "distinct_id"=> "02a99746-0f52-4acd-9a53-7deb763803ca",
+            "labels"=> [],
+            "time"=> 1452027552000,
+            "sampling_factor"=> 1,
+            "dataset"=> "$mixpanel",
+            "properties"=> {
+              "$email"=> "Alexander.Davidson@hotmailx.com",
+              "$import"=> true,
+              "country"=> "UK",
+              "load_time_ms"=> 4
+            }
+          },
+        ] * 30
+      end
 
+      def record
           {
             "name": "pageview",
             "distinct_id": "02a99746-0f52-4acd-9a53-7deb763803ca",

--- a/test/embulk/input/service/test_jql_service.rb
+++ b/test/embulk/input/service/test_jql_service.rb
@@ -555,7 +555,6 @@ module Embulk
           end
           mock(@page_builder).add(anything).times(records.length)
           mock(@page_builder).finish
-
           task_report = @plugin.run
           assert_equal("2015-03-01", task_report[:to_date])
         end

--- a/test/test_range_generator.rb
+++ b/test/test_range_generator.rb
@@ -59,7 +59,7 @@ class RangeGeneratorTest < Test::Unit::TestCase
       end
 
       def test_range_only_present
-        
+
         expected_to = today
         expected = (@from..expected_to).to_a.map{|date| date.to_s}
 


### PR DESCRIPTION
Because Mixpanel also support JQL query that brings alot of benefit and potential. We support it too. 
This PR supports JQL query for the plugins. 

api.mixpanel.com/import – track events more than 5 days old
https://help.mixpanel.com/hc/en-us/articles/360000865566-Guide-to-Mixpanel-Implementation